### PR TITLE
Standardized OT-JSON object format

### DIFF
--- a/modules/service/import-service.js
+++ b/modules/service/import-service.js
@@ -130,6 +130,26 @@ class ImportService {
         const edges = [];
         const objectIds = [];
         document['@graph'].forEach((otObject) => {
+            if (!_id(otObject) && _id(otObject) !== '') {
+                throw Error('OT-JSON object missing @id parameter');
+            }
+
+            if (!_type(otObject) && _type(otObject) !== '') {
+                throw Error(`OT-JSON object ${_id(otObject)} missing @type parameter`);
+            }
+
+            if (!otObject.identifiers) {
+                throw Error(`OT-JSON object ${_id(otObject)} missing identifiers parameter`);
+            }
+
+            if (!otObject.properties) {
+                throw Error(`OT-JSON object ${_id(otObject)} missing properties parameter`);
+            }
+
+            if (!otObject.relations) {
+                throw Error(`OT-JSON object ${_id(otObject)} missing relations parameter`);
+            }
+
             objectIds.push(Utilities.keyFrom(dataCreator, _id(otObject)));
 
             switch (_type(otObject)) {

--- a/modules/transpiler/epcis/epcis-otjson-transpiler.js
+++ b/modules/transpiler/epcis/epcis-otjson-transpiler.js
@@ -244,9 +244,13 @@ class EpcisOtJsonTranspiler {
                 }
 
                 const otVocabulary = {
+                    '@id': vocabularyElement._attributes.id,
+                    '@type': 'otObject',
                     identifiers: [],
                     relations: [],
+                    properties,
                 };
+                // TODO Find out what happens when there is no _attribute.id
                 if (vocabularyElement._attributes.id) {
                     otVocabulary.identifiers =
                         Object.entries(this._parseGS1Identifier(vocabularyElement._attributes.id))
@@ -254,10 +258,6 @@ class EpcisOtJsonTranspiler {
                 }
 
                 otVocabulary.identifiers.push(...this._findIdentifiers(vocabularyElement));
-
-                otVocabulary['@id'] = vocabularyElement._attributes.id;
-                otVocabulary.properties = properties;
-                otVocabulary['@type'] = 'otObject';
 
                 if (vocabularyElement.children) {
                     const compressedChildren = this._compressText(vocabularyElement.children);
@@ -418,16 +418,16 @@ class EpcisOtJsonTranspiler {
         const otObject = {
             '@type': 'otObject',
             '@id': id,
-            identifiers: [{
-                '@type': 'uuid',
-                '@value': id,
-            },
+            identifiers: [
+                {
+                    '@type': 'uuid',
+                    '@value': id,
+                },
             ],
-        };
-
-        otObject.relations = [];
-        otObject.properties = {
-            objectType: eventType,
+            relations: [],
+            properties: {
+                objectType: eventType,
+            },
         };
 
         const foundIdentifiers = this._findIdentifiers(event);

--- a/modules/transpiler/wot/wot-otjson-transpiler.js
+++ b/modules/transpiler/wot/wot-otjson-transpiler.js
@@ -93,20 +93,23 @@ class WotOtJsonTranspiler {
             const otObject = {
                 '@type': 'otObject',
                 '@id': id,
-                identifiers: [{
-                    '@type': 'id',
-                    '@value': id,
-                }, {
-                    '@type': 'internal_id',
-                    '@value': property.id,
-                }, {
-                    '@type': 'name',
-                    '@value': property.name,
-                },
+                identifiers: [
+                    {
+                        '@type': 'id',
+                        '@value': id,
+                    },
+                    {
+                        '@type': 'internal_id',
+                        '@value': property.id,
+                    },
+                    {
+                        '@type': 'name',
+                        '@value': property.name,
+                    },
                 ],
+                properties: property.values,
+                relations: [],
             };
-            otObject.properties = property.values;
-            otObject.relations = [];
 
             result.push(otObject);
         }
@@ -171,19 +174,19 @@ class WotOtJsonTranspiler {
         const otObject = {
             '@type': 'otObject',
             '@id': id,
-            identifiers: [{
-                '@type': 'id',
-                '@value': id,
-            },
+            identifiers: [
+                {
+                    '@type': 'id',
+                    '@value': id,
+                },
             ],
-        };
-
-        otObject.relations = [];
-        otObject.properties = {
-            id: thing.id,
-            name: thing.name,
-            description: thing.description,
-            tags: thing.tags,
+            relations: [],
+            properties: {
+                id: thing.id,
+                name: thing.name,
+                description: thing.description,
+                tags: thing.tags,
+            },
         };
 
         const createRelation = (id, relType, data) => ({
@@ -243,17 +246,17 @@ class WotOtJsonTranspiler {
                     const otObject = {
                         '@type': 'otObject',
                         '@id': obj.id,
-                        identifiers: [{
-                            '@type': 'id',
-                            '@value': obj.id,
-                        },
+                        identifiers: [
+                            {
+                                '@type': 'id',
+                                '@value': obj.id,
+                            },
                         ],
+                        relations: [],
+                        properties: {
+                            '@type': obj.type,
+                        },
                     };
-                    otObject.properties = {
-                        '@type': obj.type,
-                    };
-
-                    otObject.relations = [];
 
                     results.push(otObject);
                 }

--- a/modules/worker/graph-converter-worker.js
+++ b/modules/worker/graph-converter-worker.js
@@ -86,6 +86,27 @@ process.on('message', async (dataFromParent) => {
         const edges = [];
 
         document['@graph'].forEach((otObject) => {
+            if (!_id(otObject) && _id(otObject) !== '') {
+                throw Error('OT-JSON object missing @id parameter');
+            }
+
+            if (!_type(otObject) && _type(otObject) !== '') {
+                throw Error(`OT-JSON object ${_id(otObject)} missing @type parameter`);
+            }
+
+            if (!otObject.identifiers) {
+                throw Error(`OT-JSON object ${_id(otObject)} missing identifiers parameter`);
+            }
+
+            if (!otObject.properties) {
+                throw Error(`OT-JSON object ${_id(otObject)} missing properties parameter`);
+            }
+
+            if (!otObject.relations) {
+                throw Error(`OT-JSON object ${_id(otObject)} missing relations parameter`);
+            }
+
+
             switch (_type(otObject)) {
             case constants.objectType.otObject: {
                 // Create entity vertex.


### PR DESCRIPTION
Fixes failing replications when replicating an OT-JSON object due to superfluous adding of missing properties. Now the following properties are mandatory for each OT-JSON object, ensuring they would have a standard format when importing and retrieving from the database.

## Proposed Changes

  - 
  -
  -
