### PR TITLE
Cleaning challenges from db when offer is no longer active

### DIFF
--- a/migrations/202003051105123-update-replicated-data-add-litigation-timestamp.js
+++ b/migrations/202003051105123-update-replicated-data-add-litigation-timestamp.js
@@ -1,0 +1,14 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addColumn(
+            'replicated_data',
+            'last_litigation_timestamp',
+            {
+                type: Sequelize.DATE,
+            },
+        );
+    },
+    down: async (queryInterface) => {
+        await queryInterface.removeColumn('replicated_data', 'last_litigation_timestamp');
+    },
+};

--- a/models/replicated_data.js
+++ b/models/replicated_data.js
@@ -15,6 +15,7 @@ module.exports = (sequelize, DataTypes) => {
         distribution_epk: DataTypes.STRING,
         confirmation: DataTypes.STRING,
         status: DataTypes.STRING,
+        last_litigation_timestamp: DataTypes.DATE,
     }, {});
     replicated_data.associate = (models) => {
         // associations can be defined here

--- a/modules/command/dc/dc-challenge-check-command.js
+++ b/modules/command/dc/dc-challenge-check-command.js
@@ -31,12 +31,20 @@ class DCChallengeCheckCommand extends Command {
 
         const challenge = await models.challenges.findOne({ where: { id: challengeId } });
 
+        if (!challenge) {
+            return Command.empty();
+        }
+
         const replicatedData = await models.replicated_data.findOne({
             where:
                 {
                     offer_id: offerId, dh_id: dhId,
                 },
         });
+
+        if (!replicatedData) {
+            return Command.empty();
+        }
 
         if (challenge.answer === challenge.expected_answer) {
             this.logger.trace(`Holder ${dhIdentity} successfully answered to challenge for offer ${offerId}.`);

--- a/modules/command/dc/dc-challenge-command.js
+++ b/modules/command/dc/dc-challenge-command.js
@@ -31,6 +31,10 @@ class DCChallengeCommand extends Command {
                 id: challenge_id,
             },
         });
+        if (!challenge) {
+            // this is in case that offer expired but old commands remained
+            return Command.empty();
+        }
 
         this.logger.trace(`Sending challenge to ${challenge.dh_id}. Offer ID ${challenge.offer_id}, object_index ${challenge.object_index}, block_index ${challenge.block_index}.`);
 

--- a/modules/command/dc/dc-litigation-answered-command.js
+++ b/modules/command/dc/dc-litigation-answered-command.js
@@ -44,6 +44,16 @@ class DCLitigationAnsweredCommand extends Command {
 
                 this.logger.important(`Litigation answered for DH ${dhIdentity} and offer ${offerId}.`);
 
+                const offer = await models.offers.findOne({
+                    where: { offer_id: offerId },
+                });
+
+                if (offer.global_status === 'COMPLETED') {
+                    // offer has already been completed
+                    this.logger.warn(`Offer ${offerId} has already been completed. Skipping litigation for DH identity ${dhIdentity} with objectIndex ${objectIndex} and blockIndex ${blockIndex}`);
+                    return Command.empty();
+                }
+
                 const replicatedData = await models.replicated_data.findOne({
                     where: { offer_id: offerId, dh_identity: dhIdentity },
                 });

--- a/modules/command/dc/dc-litigation-completed-command.js
+++ b/modules/command/dc/dc-litigation-completed-command.js
@@ -52,9 +52,9 @@ class DCLitigationCompletedCommand extends Command {
                 const replicatedData = await models.replicated_data.findOne({
                     where: { offer_id: offerId, dh_identity: dhIdentity },
                 });
-
+                replicatedData.last_litigation_timestamp = new Date();
                 replicatedData.status = penalized === true ? 'PENALIZED' : 'HOLDING';
-                await replicatedData.save({ fields: ['status'] });
+                await replicatedData.save({ fields: ['status', 'last_litigation_timestamp'] });
 
                 if (penalized === true) {
                     // remove challenges

--- a/modules/command/dc/dc-litigation-initiated-command.js
+++ b/modules/command/dc/dc-litigation-initiated-command.js
@@ -51,6 +51,25 @@ class DcLitigationInitiatedCommand extends Command {
                 const offer = await Models.offers.findOne({
                     where: { offer_id: offerId },
                 });
+
+                if (offer.global_status === 'COMPLETED') {
+                    // offer has already been completed
+                    this.logger.warn(`Offer ${offerId} has already been completed. Skipping litigation for DH identity ${dhIdentity} with objectIndex ${objectIndex} and blockIndex ${blockIndex}`);
+                    return Command.empty();
+                }
+
+                await Models.replicated_data.update(
+                    {
+                        last_litigation_timestamp: new Date(),
+                    },
+                    {
+                        where: {
+                            dh_id: dhIdentity,
+                            offer_id: offerId,
+                        },
+                    },
+                );
+
                 return {
                     commands: [
                         {

--- a/modules/command/dc/dc-offer-cleanup-command.js
+++ b/modules/command/dc/dc-offer-cleanup-command.js
@@ -27,17 +27,6 @@ class DCOfferCleanupCommand extends Command {
             throw new Error(`Failed to find offer ${offerId}`);
         }
 
-        const challengingHolders = await models.replicated_data.findAll({
-            where: {
-                offer_id: offer.offer_id,
-                status: 'CHALLENGING',
-            },
-        });
-        if (challengingHolders.length > 0) {
-            this.logger.trace(`There are still challenges in progress for offer: ${offer.offer_id}, repeating cleanup command in 1 min.`);
-            return Command.repeat();
-        }
-
         offer.status = 'COMPLETED';
         offer.global_status = 'COMPLETED';
         await offer.save({ fields: ['status', 'global_status'] });
@@ -74,7 +63,6 @@ class DCOfferCleanupCommand extends Command {
             {
                 where: {
                     offer_id: offer.offer_id,
-                    status: 'HOLDING',
                 },
             },
         );


### PR DESCRIPTION
This will prevent unnecessary litigation initiated events when offer is no longer active 