### PR TITLE
Update GS1-EPCIS transpiler to store key-value pairs in the same array

### DIFF
--- a/modules/transpiler/epcis/epcis-otjson-transpiler.js
+++ b/modules/transpiler/epcis/epcis-otjson-transpiler.js
@@ -829,14 +829,7 @@ class EpcisOtJsonTranspiler {
      */
     _extractMetadata(object) {
         if (this._isLeaf(object)) {
-            const result = {};
-            if (object._attributes) {
-                result._attributes = object._attributes;
-            }
-            if (Object.keys(result).length === 0) {
-                return null;
-            }
-            return result;
+            return object;
         }
         if (Array.isArray(object)) {
             const clone = [];


### PR DESCRIPTION
## Proposed Changes

During the transpilation process from GS1-EPCIS to OT-JSON key value pair attributes are separated in two different arrays, one for keys and another one for values. During the transpilation process from OT-JSON to GS1-EPCIS key value pair attributes are constructed from two different arrays, by matching indices of key array and value array. Order of the two arrays can be modified during the sorting process.
