### PR TITLE
Enable OT-JSON Version 1.1

### DIFF
--- a/modules/ImportUtilities.js
+++ b/modules/ImportUtilities.js
@@ -673,7 +673,7 @@ class ImportUtilities {
      * Fill in dataset header
      * @private
      */
-    static createDatasetHeader(config, transpilationInfo = null, datasetTags = [], datasetTitle = '', datasetDescription = '', OTJSONVersion = '1.0') {
+    static createDatasetHeader(config, transpilationInfo = null, datasetTags = [], datasetTitle = '', datasetDescription = '', OTJSONVersion = '1.1') {
         const header = {
             OTJSONVersion,
             datasetCreationTimestamp: new Date().toISOString(),

--- a/modules/OtJsonUtilities.js
+++ b/modules/OtJsonUtilities.js
@@ -36,7 +36,7 @@ class OtJsonUtilities {
     static _getDatasetVersion(dataset) {
         if (!dataset || !dataset.datasetHeader ||
             !dataset.datasetHeader.OTJSONVersion) {
-            return '1.0';
+            return '1.1';
             // throw new Error('Could not determine dataset ot-json version!');
         }
         return dataset.datasetHeader.OTJSONVersion;

--- a/modules/transpiler/epcis/epcis-otjson-transpiler.js
+++ b/modules/transpiler/epcis/epcis-otjson-transpiler.js
@@ -1166,7 +1166,7 @@ class EpcisOtJsonTranspiler {
         return {
             transpilationInfo: {
                 transpilerType: 'GS1-EPCIS',
-                transpilerVersion: '1.0',
+                transpilerVersion: '1.1',
                 sourceMetadata: {
                     created: created.toISOString(),
                     modified: created.toISOString(),

--- a/test/modules/epcis-otjson-transpiler.test.js
+++ b/test/modules/epcis-otjson-transpiler.test.js
@@ -123,6 +123,10 @@ describe('EPCIS OT JSON transpiler tests', () => {
             // eslint-disable-next-line no-loop-func
             async () => {
                 const xmlContents = inputPermissionedDataFile.toString();
+                const expectedJson = xml2js.xml2js(xmlContents, {
+                    compact: true,
+                    spaces: 4,
+                });
                 const otJson = transpiler.convertToOTJson(xmlContents);
 
                 const attributes = otJson['@graph'][0].properties.___metadata.attribute;
@@ -134,8 +138,11 @@ describe('EPCIS OT JSON transpiler tests', () => {
                 assert.equal(permissionedDataAttributes[1]._text, 'Green');
 
                 const exportedXml = transpiler.convertFromOTJson(otJson);
-
-                assert.equal(xmlContents.trim(), exportedXml.trim());
+                const returnedJson = xml2js.xml2js(exportedXml, {
+                    compact: true,
+                    spaces: 4,
+                });
+                assert.equal(Utilities.sortObjectRecursively(expectedJson), Utilities.sortObjectRecursively(returnedJson));
             },
         );
     });


### PR DESCRIPTION
## Proposed Changes

OT-JSON 1.1 version service sorts the entire dataset except arrays in properties and saves sorted dataset in graph database. The new version of OT-JSON service improves overall performance and ensures data integrity by sorting datasets during the import process and when reading data from graph database.
