### PR TITLE
Raise the minimum token stake to 3000TRAC

### DIFF
--- a/modules/Blockchain/Ethereum/contracts/Profile.sol
+++ b/modules/Blockchain/Ethereum/contracts/Profile.sol
@@ -13,7 +13,7 @@ contract Profile {
 
     uint256 public version = 101;
 
-    uint256 public minimalStake = 10**21;
+    uint256 public minimalStake = 3*10**21;
     uint256 public withdrawalTime = 5 minutes;
 
     constructor(address hubAddress) public {


### PR DESCRIPTION
## Proposed Changes

  - Increase minimal stake balance from 1000TRAC to 3000TRAC on Profile smart contract 
  - Update nodes to require a minimum of 3000TRAC to be operational