### PR TITLE
Preserve handler_id for a delayed offer

### DIFF
--- a/modules/command/common/handler_ids_cleaner_command.js
+++ b/modules/command/common/handler_ids_cleaner_command.js
@@ -22,6 +22,7 @@ class HandlerIdsCleanerCommand extends Command {
         await Models.handler_ids.destroy({
             where: {
                 timestamp: { [Models.Sequelize.Op.lt]: timeToBeDeleted },
+                status: { [Models.Sequelize.Op.in]: ['COMPLETED', 'FAILED'] },
             },
         });
         return Command.repeat();

--- a/modules/command/dc/dc-offer-create-bc-command.js
+++ b/modules/command/dc/dc-offer-create-bc-command.js
@@ -85,6 +85,8 @@ class DCOfferCreateBcCommand extends Command {
             id: internalOfferId,
         });
 
+        await Models.handler_ids.update({ timestamp: Date.now() }, { where: { handler_id } });
+
         await this.blockchain.executePlugin('fingerprint-plugin', {
             dataSetId,
             dataRootHash,
@@ -100,19 +102,57 @@ class DCOfferCreateBcCommand extends Command {
      * @param err
      */
     async recover(command, err) {
-        const { internalOfferId, handler_id } = command.data;
+        return this.invalidateOffer(command, err);
+    }
+
+    /**
+     * Execute strategy when event is too late
+     * @param command
+     */
+    async expired(command) {
+        return this.invalidateOffer(
+            command,
+            Error('The offer creation command is too late.'),
+        );
+    }
+
+    async invalidateOffer(command, err) {
+        const { dataSetId, internalOfferId, handler_id } = command.data;
+        this.logger.notify(`Offer for data set ${dataSetId} has not been started. ${err.message}`);
+
+        const errorData = {
+            internalOfferId,
+        };
+
         const offer = await Models.offers.findOne({ where: { id: internalOfferId } });
-        offer.status = 'FAILED';
-        offer.global_status = 'FAILED';
-        offer.message = err.message;
-        await offer.save({ fields: ['status', 'message', 'global_status'] });
+        if (offer) {
+            offer.status = 'FAILED';
+            offer.global_status = 'FAILED';
+            offer.message = `Offer for data set ${dataSetId} has not been started. ${err.message}`;
+            await offer.save({ fields: ['status', 'message', 'global_status'] });
+
+            errorData.tokenAmountPerHolder = offer.token_amount_per_holder;
+            errorData.litigationIntervalInMinutes = offer.litigation_interval_in_minutes;
+            errorData.datasetId = offer.data_set_id;
+            errorData.holdingTimeInMinutes = offer.holding_time_in_minutes;
+
+            await this.replicationService.cleanup(offer.id);
+        } else {
+            this.logger.warn(`Offer with internal id ${internalOfferId} not found in database.`);
+        }
+
         this.remoteControl.offerUpdate({
             id: internalOfferId,
         });
-        Models.handler_ids.update({
-            status: 'FAILED',
-        }, { where: { handler_id } });
-        await this.replicationService.cleanup(offer.id);
+
+        await Models.handler_ids.update({ status: 'FAILED' }, { where: { handler_id } });
+
+        this.errorNotificationService.notifyError(
+            err,
+            errorData,
+            constants.PROCESS_NAME.offerHandling,
+        );
+
         return Command.empty();
     }
 
@@ -126,6 +166,7 @@ class DCOfferCreateBcCommand extends Command {
             name: 'dcOfferCreateBcCommand',
             delay: 0,
             period: constants.GAS_PRICE_VALIDITY_TIME_IN_MILLS,
+            deadline_at: Date.now() + (5 * constants.GAS_PRICE_VALIDITY_TIME_IN_MILLS),
             transactional: false,
         };
         Object.assign(command, map);

--- a/modules/command/dc/dc-offer-finalized-command.js
+++ b/modules/command/dc/dc-offer-finalized-command.js
@@ -119,6 +119,8 @@ class DcOfferFinalizedCommand extends Command {
                 };
             }
         }
+
+        await Models.handler_ids.update({ timestamp: Date.now() }, { where: { handler_id } });
         return Command.repeat();
     }
 

--- a/modules/command/dc/dc-offer-task-command.js
+++ b/modules/command/dc/dc-offer-task-command.js
@@ -76,6 +76,8 @@ class DcOfferTaskCommand extends Command {
             this.logger.trace(`Offer successfully started for data set ${dataSetIdNorm}. Offer ID ${eventOfferId}. Internal offer ID ${internalOfferId}.`);
             return this.continueSequence(this.pack(command.data), command.sequence);
         }
+
+        await Models.handler_ids.update({ timestamp: Date.now() }, { where: { handler_id } });
         return Command.repeat();
     }
 
@@ -84,7 +86,10 @@ class DcOfferTaskCommand extends Command {
      * @param command
      */
     async expired(command) {
-        return this.invalidateOffer(command);
+        return this.invalidateOffer(
+            command,
+            Error('The offer task event is too late.'),
+        );
     }
 
     /**

--- a/modules/command/dh/dh-offer-finalized-command.js
+++ b/modules/command/dh/dh-offer-finalized-command.js
@@ -1,6 +1,7 @@
 const Command = require('../command');
 const Utilities = require('../../Utilities');
 const Models = require('../../../models/index');
+const constants = require('../../constants');
 
 /**
  * Repeatable command that checks whether offer is ready or not
@@ -111,7 +112,7 @@ class DhOfferFinalizedCommand extends Command {
             name: 'dhOfferFinalizedCommand',
             delay: 0,
             period: 10 * 1000,
-            deadline_at: Date.now() + (60 * 60 * 1000), // On hour.
+            deadline_at: Date.now() + (6 * constants.GAS_PRICE_VALIDITY_TIME_IN_MILLS),
             transactional: false,
         };
         Object.assign(command, map);

--- a/modules/command/dh/dh-offer-finalized-command.js
+++ b/modules/command/dh/dh-offer-finalized-command.js
@@ -93,7 +93,7 @@ class DhOfferFinalizedCommand extends Command {
     async expired(command) {
         const { offerId } = command.data;
 
-        this.logger.important(`I haven't been chosen for offer ${offerId}. Offer has not been finalized.`);
+        this.logger.important(`Offer ${offerId} has not been finalized.`);
         const bid = await Models.bids.findOne({ where: { offer_id: offerId } });
         bid.status = 'NOT_CHOSEN';
         await bid.save({ fields: ['status'] });

--- a/modules/service/dc-service.js
+++ b/modules/service/dc-service.js
@@ -30,6 +30,8 @@ class DCService {
      * @param tokenAmountPerHolder
      * @param dataSizeInBytes
      * @param litigationIntervalInMinutes
+     * @param handler_id
+     * @param urgent
      * @returns {Promise<*>}
      */
     async createOffer(
@@ -293,6 +295,7 @@ class DCService {
             const message = `Replication request for offer external ${offerId} that is not in STARTED state.`;
             this.logger.warn(message);
             await this.transport.sendResponse(response, { status: 'fail', message });
+            return;
         }
 
         const dhReputation = await this.getReputationForDh(dhIdentity);
@@ -301,9 +304,10 @@ class DCService {
             const message = `Replication request from holder identity ${dhIdentity} declined! Unacceptable reputation: ${dhReputation.toString()}.`;
             this.logger.info(message);
             await this.transport.sendResponse(response, { status: 'fail', message });
-        } else {
-            await this._sendReplication(offer, wallet, identity, dhIdentity, response);
+            return;
         }
+
+        await this._sendReplication(offer, wallet, identity, dhIdentity, response);
     }
 
     /**

--- a/modules/service/rest-api-v2.js
+++ b/modules/service/rest-api-v2.js
@@ -590,7 +590,14 @@ class RestAPIServiceV2 {
         };
         const offer = await Models.offers.findOne({
             where: {
-                offer_id: handlerData.offer_id,
+                $or: [
+                    {
+                        offer_id: { $eq: handlerData.offer_id },
+                    },
+                    {
+                        id: { $eq: handlerData.offer_id },
+                    },
+                ],
             },
         });
         if (offer) {

--- a/modules/service/rest-api-v2.js
+++ b/modules/service/rest-api-v2.js
@@ -590,12 +590,12 @@ class RestAPIServiceV2 {
         };
         const offer = await Models.offers.findOne({
             where: {
-                $or: [
+                [Models.Sequelize.Op.or]: [
                     {
-                        offer_id: { $eq: handlerData.offer_id },
+                        offer_id: handlerData.offer_id,
                     },
                     {
-                        id: { $eq: handlerData.offer_id },
+                        id: handlerData.offer_id,
                     },
                 ],
             },


### PR DESCRIPTION
## Proposed Changes

  - Only delete handler records if they are in `COMPLETED` or `FAILED` state
  - Update handler record's timestamp every time an offer-related command is delayed
  - Update handler and offer info with the appropriate information when a command is delayed
  - Introduce a deadline for offer creation and completion commands (set to `5 * GAS_PRICE_VALIDITY` )
     - Add a similar deadline to dhOfferFinalized command (set to `6 * GAS_PRICE_VALIDITY` )

### Fixes
  - Fix error where DC would try to send a deleted replication when the offer is not in `STARTED` state
  - Fix missing data for `/replicate/status/` API route when offer_id is not yet created