### PR TITLE
Added a 30 minute period to existing payOut commands

### DIFF
--- a/migrations/202010181032127-update-commands-add-payout-period.js
+++ b/migrations/202010181032127-update-commands-add-payout-period.js
@@ -1,0 +1,9 @@
+const constats = require('../modules/constants');
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        const period = constats.GAS_PRICE_VALIDITY_TIME_IN_MILLS;
+        await queryInterface.sequelize.query(`UPDATE commands SET period = ${period} WHERE name = 'dhPayOutCommand'`);
+    },
+    down: async (queryInterface) => { },
+};

--- a/modules/command/dh/dh-offer-finalized-command.js
+++ b/modules/command/dh/dh-offer-finalized-command.js
@@ -64,6 +64,7 @@ class DhOfferFinalizedCommand extends Command {
                                 {
                                     name: 'dhPayOutCommand',
                                     delay: scheduledTime,
+                                    period: constants.GAS_PRICE_VALIDITY_TIME_IN_MILLS,
                                     retries: 3,
                                     transactional: false,
                                     data: {


### PR DESCRIPTION
## Proposed Changes

  - Add a migration file which adds a period of 30 minutes to existing payOut commands
  - Fix missing period parameter for future payOut commands
