### PR TITLE
Enabled OT-JSON version 1.2

### DIFF
--- a/modules/ImportUtilities.js
+++ b/modules/ImportUtilities.js
@@ -676,7 +676,7 @@ class ImportUtilities {
      * Fill in dataset header
      * @private
      */
-    static createDatasetHeader(config, transpilationInfo = null, datasetTags = [], datasetTitle = '', datasetDescription = '', OTJSONVersion = '1.1', datasetCreationTimestamp = new Date().toISOString()) {
+    static createDatasetHeader(config, transpilationInfo = null, datasetTags = [], datasetTitle = '', datasetDescription = '', OTJSONVersion = '1.2', datasetCreationTimestamp = new Date().toISOString()) {
         const header = {
             OTJSONVersion,
             datasetCreationTimestamp,

--- a/modules/OtJsonUtilities.js
+++ b/modules/OtJsonUtilities.js
@@ -36,7 +36,7 @@ class OtJsonUtilities {
     static _getDatasetVersion(dataset) {
         if (!dataset || !dataset.datasetHeader ||
             !dataset.datasetHeader.OTJSONVersion) {
-            return '1.1';
+            return '1.2';
             // throw new Error('Could not determine dataset ot-json version!');
         }
         return dataset.datasetHeader.OTJSONVersion;


### PR DESCRIPTION
## Proposed Changes

OT-JSON 1.2 version sorts entire datasets except arrays in properties and saves sorted dataset in graph database. The new version of OT-JSON service improves overall performance and ensures data integrity by sorting datasets during the import process and when reading data from graph database.


