### PR TITLE
Fixed the default blockchain configuration being overriden

### DIFF
--- a/ot-node.js
+++ b/ot-node.js
@@ -63,10 +63,10 @@ const log = require('./modules/logger');
 global.__basedir = __dirname;
 
 let context;
-const defaultConfig = configjson[
+const defaultConfig = Utilities.copyObject(configjson[
     process.env.NODE_ENV &&
     ['development', 'testnet', 'mainnet'].indexOf(process.env.NODE_ENV) >= 0 ?
-        process.env.NODE_ENV : 'development'];
+        process.env.NODE_ENV : 'development']);
 
 let config;
 try {

--- a/test/modules/service/pricing-service-test.js
+++ b/test/modules/service/pricing-service-test.js
@@ -105,18 +105,18 @@ describe('Pricing service test', () => {
     it('Get gas price - env is mainnet, all services return valid value - expect axios value is used', async () => {
         const gasPrice = await blockchain.getGasPrice().response;
         assert.equal(gasPrice, defaultGasStationGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Returned gas price price should be the same as default axios gas price');
-        assert.equal(config.blockchain.implementations[0].gas_price, defaultGasStationGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Configuration gas price should be the same as default axios gas price');
+        assert.equal(blockchain.blockchain[0].config.gas_price, defaultGasStationGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Configuration gas price should be the same as default axios gas price');
         const now = new Date().getTime();
-        assert.closeTo(config.blockchain.implementations[0].gas_price_last_update_timestamp, now, 1000, 'Now should be set as new timestamp');
+        assert.closeTo(blockchain.blockchain[0].config.gas_price_last_update_timestamp, now, 1000, 'Now should be set as new timestamp');
     });
 
     it('Get gas price - env is mainnet, all services return valid value, timestamp is not older than 30 min - expect config value is used', async () => {
         const lastUpdateTimestamp = new Date().getTime() - (1000 * 25);
-        config.blockchain.implementations[0].gas_price_last_update_timestamp = lastUpdateTimestamp;
+        blockchain.blockchain[0].config.gas_price_last_update_timestamp = lastUpdateTimestamp;
         pricingService.config = config;
         const gasPrice = await blockchain.getGasPrice().response;
-        assert.equal(gasPrice, config.blockchain.implementations[0].gas_price, 'Gas price should be the same as default config');
-        assert.equal(config.blockchain.implementations[0].gas_price_last_update_timestamp, lastUpdateTimestamp, 'Timestamp should not be changed');
+        assert.equal(gasPrice, blockchain.blockchain[0].config.gas_price, 'Gas price should be the same as default config');
+        assert.equal(blockchain.blockchain[0].config.gas_price_last_update_timestamp, lastUpdateTimestamp, 'Timestamp should not be changed');
     });
 
     it('Get gas price - env is mainnet, axios returns undefined - expect web3 value is used', async () => {
@@ -126,8 +126,8 @@ describe('Pricing service test', () => {
         const gasPrice = await blockchain.getGasPrice().response;
         const now = new Date().getTime();
         assert.equal(gasPrice, defaultWeb3GasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default web3');
-        assert.equal(config.blockchain.implementations[0].gas_price, defaultWeb3GasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default web3');
-        assert.closeTo(config.blockchain.implementations[0].gas_price_last_update_timestamp, now, 1000, 'Timestamp should not be changed');
+        assert.equal(blockchain.blockchain[0].config.gas_price, defaultWeb3GasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default web3');
+        assert.closeTo(blockchain.blockchain[0].config.gas_price_last_update_timestamp, now, 1000, 'Timestamp should not be changed');
     });
 
     it('Get gas price - env is mainnet, web3 returns undefined - expect axios value is used', async () => {
@@ -137,8 +137,8 @@ describe('Pricing service test', () => {
         const gasPrice = await blockchain.getGasPrice().response;
         const now = new Date().getTime();
         assert.equal(gasPrice, defaultGasStationGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default axios');
-        assert.equal(config.blockchain.implementations[0].gas_price, defaultGasStationGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default axios');
-        assert.closeTo(config.blockchain.implementations[0].gas_price_last_update_timestamp, now, 1000, 'Timestamp should not be changed');
+        assert.equal(blockchain.blockchain[0].config.gas_price, defaultGasStationGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default axios');
+        assert.closeTo(blockchain.blockchain[0].config.gas_price_last_update_timestamp, now, 1000, 'Timestamp should not be changed');
     });
 
     it('Calculate offer price in trac - data size in bytes not provided - expect error', async () => {


### PR DESCRIPTION
Because the blockchain implementation configuration is an array it gets completely overridden by the user specified implementation configuration. Meaning that if a user doesn't specify a parameter it will not be loaded from the blockchain implementation, but instead it will be completely deleted. 

The image below shows what happens if a DH doesn't specify the `dh_price_factor`. The price factor is deleted.

![Screen Shot 2020-11-20 at 8 47 38 PM](https://user-images.githubusercontent.com/33048701/99843609-201d7680-2b72-11eb-993c-fee0ca05e4b1.png)

With these changes the default blockchain configuration will be matched by the `blockchain_title`. What this means is best explained by an example:
If a user has two blockchain implementations with the `Ethereum` blockchain title, the default parameters for the Ethereum blockchain will be loaded for both implementations.
This matching mechanism introduces a necessary requirement  which states that in the user defined configuration, each blockchain implementation object *must* have the `blockchain_title` parameter, otherwise the node will abort startup.
