### PR TITLE
Resolve replication bug when node doesn't have enough tokens

### DIFF
--- a/modules/command/dc/dc-offer-prepare-command.js
+++ b/modules/command/dc/dc-offer-prepare-command.js
@@ -59,6 +59,8 @@ class DCOfferPrepareCommand extends Command {
             price_factor_used_for_price_calculation: this.config.blockchain.dc_price_factor,
         });
 
+        command.data.internalOfferId = offer.id;
+
         if (!command.data.litigationIntervalInMinutes) {
             command.data.litigationIntervalInMinutes =
                 new BN(this.config.dc_litigation_interval_in_minutes, 10);
@@ -100,7 +102,6 @@ class DCOfferPrepareCommand extends Command {
                 handler_id,
             },
         });
-        command.data.internalOfferId = offer.id;
 
         // export dataset from db
         this.logger.info(`Exporting dataset: ${dataSetId}. For internal offer id: ${offer.id}.`);
@@ -163,7 +164,7 @@ class DCOfferPrepareCommand extends Command {
         this.remoteControl.offerUpdate({
             id: internalOfferId,
         });
-        Models.handler_ids.update({
+        await Models.handler_ids.update({
             status: 'FAILED',
         }, { where: { handler_id } });
 

--- a/modules/service/rest-api-v2.js
+++ b/modules/service/rest-api-v2.js
@@ -501,40 +501,45 @@ class RestAPIServiceV2 {
             return;
         }
         const handlerData = JSON.parse(handler_object.data);
-
-        const offerData = {
-            status: handlerData.status,
-            holders: handlerData.holders,
-        };
-        const offer = await Models.offers.findOne({
-            where: {
-                [Models.Sequelize.Op.or]: [
-                    {
-                        offer_id: handlerData.offer_id,
-                    },
-                    {
-                        id: handlerData.offer_id,
-                    },
-                ],
-            },
-        });
-        if (offer) {
-            offerData.number_of_replications = offer.number_of_replications;
-            offerData.number_of_verified_replications = offer.number_of_verified_replications;
-            offerData.trac_in_eth_used_for_price_calculation =
-                offer.trac_in_eth_used_for_price_calculation;
-            offerData.gas_price_used_for_price_calculation =
-                offer.gas_price_used_for_price_calculation;
-            offerData.price_factor_used_for_price_calculation =
-                offer.price_factor_used_for_price_calculation;
-            offerData.offer_create_transaction_hash = offer.transaction_hash;
-            offerData.offer_finalize_transaction_hash = offer.offer_finalize_transaction_hash;
-            offerData.offer_id = offer.offer_id;
-            offerData.holding_time_in_minutes = offer.holding_time_in_minutes;
-            offerData.token_amount_per_holder = offer.token_amount_per_holder;
-            offerData.message = offer.message;
+        let offerData;
+        if (handlerData) {
+            offerData = {
+                status: handlerData.status,
+                holders: handlerData.holders,
+            };
+            const offer = await Models.offers.findOne({
+                where: {
+                    [Models.Sequelize.Op.or]: [
+                        {
+                            offer_id: handlerData.offer_id,
+                        },
+                        {
+                            id: handlerData.offer_id,
+                        },
+                    ],
+                },
+            });
+            if (offer) {
+                offerData.number_of_replications = offer.number_of_replications;
+                offerData.number_of_verified_replications = offer.number_of_verified_replications;
+                offerData.trac_in_eth_used_for_price_calculation =
+                    offer.trac_in_eth_used_for_price_calculation;
+                offerData.gas_price_used_for_price_calculation =
+                    offer.gas_price_used_for_price_calculation;
+                offerData.price_factor_used_for_price_calculation =
+                    offer.price_factor_used_for_price_calculation;
+                offerData.offer_create_transaction_hash = offer.transaction_hash;
+                offerData.offer_finalize_transaction_hash = offer.offer_finalize_transaction_hash;
+                offerData.offer_id = offer.offer_id;
+                offerData.holding_time_in_minutes = offer.holding_time_in_minutes;
+                offerData.token_amount_per_holder = offer.token_amount_per_holder;
+                offerData.message = offer.message;
+            }
+            Object.keys(offerData).forEach(key =>
+                (offerData[key] == null) && delete offerData[key]);
+        } else {
+            offerData = {};
         }
-        Object.keys(offerData).forEach(key => (offerData[key] == null) && delete offerData[key]);
         res.status(200);
         res.send({
             data: offerData,


### PR DESCRIPTION
Fixes #

If node doesn't have enough tokens prior to replication request it isn't possible to retrieve replication status later.