### PR TITLE
Add a delay to replication data send command

### DIFF
--- a/migrations/202104201448123-update-offers-add-replication-timestamp.js
+++ b/migrations/202104201448123-update-offers-add-replication-timestamp.js
@@ -1,0 +1,14 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addColumn(
+            'offers',
+            'replication_start_timestamp',
+            {
+                type: Sequelize.String,
+            },
+        );
+    },
+    down: async (queryInterface) => {
+        await queryInterface.removeColumn('offers', 'replication_start_timestamp');
+    },
+};

--- a/migrations/202104201448123-update-offers-add-replication-timestamp.js
+++ b/migrations/202104201448123-update-offers-add-replication-timestamp.js
@@ -4,7 +4,7 @@ module.exports = {
             'offers',
             'replication_start_timestamp',
             {
-                type: Sequelize.String,
+                type: Sequelize.STRING,
             },
         );
     },

--- a/models/offers.js
+++ b/models/offers.js
@@ -28,6 +28,7 @@ module.exports = (sequelize, DataTypes) => {
         price_factor_used_for_price_calculation: DataTypes.INTEGER,
         offer_finalize_transaction_hash: DataTypes.STRING(128),
         blockchain_id: DataTypes.STRING,
+        replication_start_timestamp: DataTypes.STRING,
     }, {});
     offers.associate = (models) => {
     // associations can be defined here

--- a/modules/command/dc/dc-offer-finalized-command.js
+++ b/modules/command/dc/dc-offer-finalized-command.js
@@ -18,6 +18,7 @@ class DcOfferFinalizedCommand extends Command {
         this.logger = ctx.logger;
         this.config = ctx.config;
         this.graphStorage = ctx.graphStorage;
+        this.dcService = ctx.dcService;
         this.challengeService = ctx.challengeService;
         this.replicationService = ctx.replicationService;
         this.remoteControl = ctx.remoteControl;
@@ -108,6 +109,9 @@ class DcOfferFinalizedCommand extends Command {
                         },
                     },
                 });
+
+
+                delete this.dcService.tempMapping[offerId];
 
                 const delayOnComplete = 5 * 60 * 1000; // 5 minutes
                 const scheduledTime = (offer.holding_time_in_minutes * 60 * 1000) + delayOnComplete;
@@ -225,6 +229,9 @@ class DcOfferFinalizedCommand extends Command {
         await Models.handler_ids.update({
             status: 'FAILED',
         }, { where: { handler_id } });
+
+
+        delete this.dcService.tempMapping[offerId];
 
         this.errorNotificationService.notifyError(
             err,

--- a/modules/command/dc/dc-offer-finalized-command.js
+++ b/modules/command/dc/dc-offer-finalized-command.js
@@ -110,9 +110,6 @@ class DcOfferFinalizedCommand extends Command {
                     },
                 });
 
-
-                delete this.dcService.tempMapping[offerId];
-
                 const delayOnComplete = 5 * 60 * 1000; // 5 minutes
                 const scheduledTime = (offer.holding_time_in_minutes * 60 * 1000) + delayOnComplete;
                 return {
@@ -229,9 +226,6 @@ class DcOfferFinalizedCommand extends Command {
         await Models.handler_ids.update({
             status: 'FAILED',
         }, { where: { handler_id } });
-
-
-        delete this.dcService.tempMapping[offerId];
 
         this.errorNotificationService.notifyError(
             err,

--- a/modules/command/dc/dc-offer-task-command.js
+++ b/modules/command/dc/dc-offer-task-command.js
@@ -59,11 +59,12 @@ class DcOfferTaskCommand extends Command {
             }
             offer.task = eventTask;
             offer.offer_id = eventOfferId;
+            offer.replication_start_timestamp = Date.now().toString();
             offer.status = 'STARTED';
             offer.message = 'Offer has been successfully started. Waiting for DHs...';
-            await offer.save({ fields: ['task', 'offer_id', 'status', 'message'] });
-
-            this.dcService.tempMapping[eventOfferId] = Date.now();
+            await offer.save({
+                fields: ['task', 'offer_id', 'replication_start_timestamp', 'status', 'message'],
+            });
 
             this.remoteControl.offerUpdate({
                 id: internalOfferId,

--- a/modules/command/dc/dc-offer-task-command.js
+++ b/modules/command/dc/dc-offer-task-command.js
@@ -12,6 +12,7 @@ class DcOfferTaskCommand extends Command {
     constructor(ctx) {
         super(ctx);
         this.logger = ctx.logger;
+        this.dcService = ctx.dcService;
         this.replicationService = ctx.replicationService;
         this.remoteControl = ctx.remoteControl;
         this.errorNotificationService = ctx.errorNotificationService;
@@ -61,6 +62,9 @@ class DcOfferTaskCommand extends Command {
             offer.status = 'STARTED';
             offer.message = 'Offer has been successfully started. Waiting for DHs...';
             await offer.save({ fields: ['task', 'offer_id', 'status', 'message'] });
+
+            this.dcService.tempMapping[eventOfferId] = Date.now();
+
             this.remoteControl.offerUpdate({
                 id: internalOfferId,
             });

--- a/modules/command/dc/dc-replication-send-command.js
+++ b/modules/command/dc/dc-replication-send-command.js
@@ -30,9 +30,12 @@ class DCReplicationSendCommand extends Command {
     async execute(command) {
         const {
             internalOfferId, wallet, identity, dhIdentity, offerId, blockchainId,
+            replicationStartTime,
         } = command.data;
 
-        if ((this.dcService.tempMapping[offerId] + this.config.dc_choose_time) < Date.now()) {
+        // Check if the replication window expired
+        if ((replicationStartTime + this.config.dc_choose_time) < Date.now()) {
+            this.logger.debug(`Too late to send the replication for offer ${offerId} to ${identity}.`);
             return Command.empty();
         }
 
@@ -41,7 +44,7 @@ class DCReplicationSendCommand extends Command {
         if (!purposes.includes('2')) {
             const message = 'Wallet provided does not have the appropriate permissions set up for the given identity.';
             this.logger.warn(message);
-            // await this.transport.sendResponse(response, { status: 'fail', message });
+            // TODO Send some response to DH to avoid pointlessly waiting
             return Command.empty();
         }
 

--- a/modules/command/dc/dc-replication-send-command.js
+++ b/modules/command/dc/dc-replication-send-command.js
@@ -49,35 +49,33 @@ class DCReplicationSendCommand extends Command {
                 offer_id: offerId,
             },
         });
-
-        let colorNumber = Utilities.getRandomInt(2);
-        if (usedDH != null && usedDH.status === 'STARTED' && usedDH.color) {
-            colorNumber = usedDH.color;
+        if (usedDH) {
+            return Command.empty();
         }
+
+        const colorNumber = Utilities.getRandomInt(2);
 
         const color = this.replicationService.castNumberToColor(colorNumber);
 
         const offer = await Models.offers.findOne({ where: { id: internalOfferId } });
         const replication = await this.replicationService.loadReplication(offer.id, color);
 
-        if (!usedDH) {
-            await Models.replicated_data.create({
-                dh_id: identity,
-                dh_wallet: wallet.toLowerCase(),
-                dh_identity: dhIdentity.toLowerCase(),
-                offer_id: offer.offer_id,
-                litigation_private_key: replication.litigationPrivateKey,
-                litigation_public_key: replication.litigationPublicKey,
-                distribution_public_key: replication.distributionPublicKey,
-                distribution_private_key: replication.distributionPrivateKey,
-                distribution_epk_checksum: replication.distributionEpkChecksum,
-                litigation_root_hash: replication.litigationRootHash,
-                distribution_root_hash: replication.distributionRootHash,
-                distribution_epk: replication.distributionEpk,
-                status: 'STARTED',
-                color: colorNumber,
-            });
-        }
+        await Models.replicated_data.create({
+            dh_id: identity,
+            dh_wallet: wallet.toLowerCase(),
+            dh_identity: dhIdentity.toLowerCase(),
+            offer_id: offer.offer_id,
+            litigation_private_key: replication.litigationPrivateKey,
+            litigation_public_key: replication.litigationPublicKey,
+            distribution_public_key: replication.distributionPublicKey,
+            distribution_private_key: replication.distributionPrivateKey,
+            distribution_epk_checksum: replication.distributionEpkChecksum,
+            litigation_root_hash: replication.litigationRootHash,
+            distribution_root_hash: replication.distributionRootHash,
+            distribution_epk: replication.distributionEpk,
+            status: 'STARTED',
+            color: colorNumber,
+        });
 
         const toSign = [
             Utilities.denormalizeHex(new BN(replication.distributionEpkChecksum).toString('hex')),

--- a/modules/command/dc/dc-replication-send-command.js
+++ b/modules/command/dc/dc-replication-send-command.js
@@ -14,6 +14,7 @@ class DCReplicationSendCommand extends Command {
         this.logger = ctx.logger;
         this.transport = ctx.transport;
         this.blockchain = ctx.blockchain;
+        this.dcService = ctx.dcService;
 
         this.replicationService = ctx.replicationService;
         this.permissionedDataService = ctx.permissionedDataService;
@@ -30,6 +31,10 @@ class DCReplicationSendCommand extends Command {
         const {
             internalOfferId, wallet, identity, dhIdentity, offerId, blockchainId,
         } = command.data;
+
+        if ((this.dcService.tempMapping[offerId] + this.config.dc_choose_time) < Date.now()) {
+            return Command.empty();
+        }
 
         const purposes = await this.blockchain
             .getWalletPurposes(dhIdentity, wallet, blockchainId).response;

--- a/modules/command/dc/dc-replication-send-command.js
+++ b/modules/command/dc/dc-replication-send-command.js
@@ -28,8 +28,17 @@ class DCReplicationSendCommand extends Command {
      */
     async execute(command) {
         const {
-            internalOfferId, wallet, identity, dhIdentity, offerId,
+            internalOfferId, wallet, identity, dhIdentity, offerId, blockchainId,
         } = command.data;
+
+        const purposes = await this.blockchain
+            .getWalletPurposes(dhIdentity, wallet, blockchainId).response;
+        if (!purposes.includes('2')) {
+            const message = 'Wallet provided does not have the appropriate permissions set up for the given identity.';
+            this.logger.warn(message);
+            // await this.transport.sendResponse(response, { status: 'fail', message });
+            return Command.empty();
+        }
 
 
         const usedDH = await Models.replicated_data.findOne({

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -2,6 +2,10 @@
  * @constant {number} DEFAULT_NUMBER_OF_HOLDERS - Number of data holders for a dataset
  */
 exports.DEFAULT_NUMBER_OF_HOLDERS = 3;
+/**
+ * @constant {number} DEFAULT_NUMBER_OF_HOLDERS - Number of data holders for a dataset
+ */
+exports.REPLICATION_MIN_DELAY_MILLS = 4 * 60 * 1000;
 
 /**
  * @constant {number} DEFAULT_CHALLENGE_NUMBER_OF_TESTS - Number of challenges per DH

--- a/modules/service/dc-service.js
+++ b/modules/service/dc-service.js
@@ -7,8 +7,10 @@ const models = require('../../models');
 const constants = require('../constants');
 const ImportUtilities = require('../ImportUtilities');
 
+
 class DCService {
     constructor(ctx) {
+        this.tempMapping = {};
         this.transport = ctx.transport;
         this.logger = ctx.logger;
         this.config = ctx.config;
@@ -266,15 +268,6 @@ class DCService {
             return;
         }
 
-        const purposes = await this.blockchain
-            .getWalletPurposes(dhIdentity, wallet, offer.blockchain_id).response;
-        if (!purposes.includes('2')) {
-            const message = 'Wallet provided does not have the appropriate permissions set up for the given identity.';
-            this.logger.warn(message);
-            await this.transport.sendResponse(response, { status: 'fail', message });
-            return;
-        }
-
         const dhReputation = await this.getReputationForDh(dhIdentity);
 
         if (dhReputation.lt(new BN(this.config.dh_min_reputation))) {
@@ -287,9 +280,15 @@ class DCService {
         if (async_enabled) {
             await this._sendReplicationAcknowledgement(offerId, identity, response);
 
+            const currentTime = Date.now();
+            let lower = this.tempMapping[offerId] + 4 * 60 * 1000; // + this.config.dc_choose_time * 0.5;
+            const upper = this.tempMapping[offerId] + this.config.dc_choose_time * 0.9;
+            const scheduledTime = Math.ceil(Math.random() * (upper - lower) + lower);
+            const delay = scheduledTime - currentTime;
+
             await this.commandExecutor.add({
                 name: 'dcReplicationSendCommand',
-                delay: 0,
+                delay: (delay > 0 ? delay : 0),
                 data: {
                     internalOfferId: offer.id,
                     offerId,
@@ -297,6 +296,7 @@ class DCService {
                     identity,
                     dhIdentity,
                     response,
+                    blockchainId: offer.blockchain_id,
                 },
                 transactional: false,
             });


### PR DESCRIPTION
Fixes #1506

## Proposed Changes
By delaying the replication sending command we're reducing the load on the DC node at a crucial moment, when a large number of nodes are sending replication requests.

This load reduction will enable the DC node to answer faster to requests, which will reduce dropped and duplicated requests.

Even if the DC node does get overloaded, it will skip sending replications if the bidding window is closed, enabling offers to be finalized within a reasonable time frame even if it wasn't sent to all nodes which requested the dataset.

  - Add a delay between 4 and 108 minutes after sending bid acknowledgement and sending the replication data
  - Stop sending replications if the replication window has closed
