### PR TITLE
Added operation db validation after backup is performed

### DIFF
--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -160,7 +160,8 @@ function backupOperationalDb(backupDir) {
         numberOfRetries += 1;
         if (result) {
             try {
-                execSync('sqlite3 ../data/system.db');
+                const destination = path.join(backupDir, operationalDbFileName);
+                execSync(`sqlite3 ${destination}`);
                 runInLoop = false;
             } catch (error) {
                 if (numberOfRetries === operationDbBackupMaxNumberOfRetries) {


### PR DESCRIPTION
Fixes #
Now when operation db backup is finalised node will check if backup file is corrupted. If the file is corrupted node will retry to perform the backup of operation db again in loop for 10 times before throwing an error.
