### PR TITLE
send store queries in parallel when publishing

### DIFF
--- a/modules/command/publish/send-assertion-command.js
+++ b/modules/command/publish/send-assertion-command.js
@@ -31,7 +31,7 @@ class SendAssertionCommand extends Command {
 
         for (const node of nodes) {
             try {
-                await this.publishService.store({ rdf, id: assertion.id }, node);
+                this.publishService.store({ rdf, id: assertion.id }, node);
             } catch (e) {
                 this.logger.error(`Error while sending data with assertion id ${assertion.id} to node ${node._idB58String}. Error message: ${e.message}. ${e.stack}`);
                 this.logger.emit({

--- a/modules/command/publish/send-assertion-command.js
+++ b/modules/command/publish/send-assertion-command.js
@@ -1,66 +1,71 @@
-const Command = require('../command');
+const Command = require("../command");
 
 class SendAssertionCommand extends Command {
-    constructor(ctx) {
-        super(ctx);
-        this.logger = ctx.logger;
-        this.config = ctx.config;
-        this.networkService = ctx.networkService;
-        this.publishService = ctx.publishService;
+  constructor(ctx) {
+    super(ctx);
+    this.logger = ctx.logger;
+    this.config = ctx.config;
+    this.networkService = ctx.networkService;
+    this.publishService = ctx.publishService;
+  }
+
+  /**
+   * Executes command and produces one or more events
+   * @param command
+   */
+  async execute(command) {
+    const { rdf, assertion, assets, keywords } = command.data;
+
+    let nodes = [];
+    for (const keyword of keywords) {
+      this.logger.info(
+        `Searching for closest ${this.config.replicationFactor} node(s) for keyword ${keyword}`
+      );
+      const foundNodes = await this.networkService.findNodes(
+        keyword,
+        this.config.replicationFactor
+      );
+      if (foundNodes.length < this.config.replicationFactor) {
+        this.logger.warn(
+          `Found only ${foundNodes.length} node(s) for keyword ${keyword}`
+        );
+      }
+      nodes = nodes.concat(foundNodes);
+    }
+    nodes = [...new Set(nodes)];
+
+    for (const node of nodes) {
+      this.publishService.store({ rdf, id: assertion.id }, node).catch((e) => {
+        this.logger.error(
+          `Error while sending data with assertion id ${assertion.id} to node ${node._idB58String}. Error message: ${e.message}. ${e.stack}`
+        );
+        this.logger.emit({
+          msg: "Telemetry logging error at sending assertion command",
+          Operation_name: "Error",
+          Event_name: "SendAssertionError",
+          Event_value1: e.message,
+          Id_operation: "Undefined",
+        });
+      });
     }
 
-    /**
-     * Executes command and produces one or more events
-     * @param command
-     */
-    async execute(command) {
-        const {
-            rdf, assertion, assets, keywords,
-        } = command.data;
+    return this.continueSequence(command.data, command.sequence);
+  }
 
-        let nodes = [];
-        for (const keyword of keywords) {
-            this.logger.info(`Searching for closest ${this.config.replicationFactor} node(s) for keyword ${keyword}`);
-            const foundNodes = await this.networkService.findNodes(keyword, this.config.replicationFactor);
-            if (foundNodes.length < this.config.replicationFactor) {
-                this.logger.warn(`Found only ${foundNodes.length} node(s) for keyword ${keyword}`);
-            }
-            nodes = nodes.concat(foundNodes);
-        }
-        nodes = [...new Set(nodes)];
-
-        for (const node of nodes) {
-            try {
-                this.publishService.store({ rdf, id: assertion.id }, node);
-            } catch (e) {
-                this.logger.error(`Error while sending data with assertion id ${assertion.id} to node ${node._idB58String}. Error message: ${e.message}. ${e.stack}`);
-                this.logger.emit({
-                    msg: 'Telemetry logging error at sending assertion command',
-                    Operation_name: 'Error',
-                    Event_name: 'SendAssertionError',
-                    Event_value1: e.message,
-                    Id_operation: 'Undefined',
-                });
-            }
-        }
-
-        return this.continueSequence(command.data, command.sequence);
-    }
-
-    /**
-     * Builds default dcConvertToOtJsonCommand
-     * @param map
-     * @returns {{add, data: *, delay: *, deadline: *}}
-     */
-    default(map) {
-        const command = {
-            name: 'sendAssertionCommand',
-            delay: 0,
-            transactional: false,
-        };
-        Object.assign(command, map);
-        return command;
-    }
+  /**
+   * Builds default dcConvertToOtJsonCommand
+   * @param map
+   * @returns {{add, data: *, delay: *, deadline: *}}
+   */
+  default(map) {
+    const command = {
+      name: "sendAssertionCommand",
+      delay: 0,
+      transactional: false,
+    };
+    Object.assign(command, map);
+    return command;
+  }
 }
 
 module.exports = SendAssertionCommand;


### PR DESCRIPTION
Fixes # 

When publishing data, nodes currently contact keywords' "closest" nodes sequentially. This means that if one node doesn't respond, the node is stuck waiting and never contacts the others.

## Proposed Changes

  -Removing `await` before `this.publishService.store({ rdf, id: assertion.id }, node);` in `send-assertion-command.js` enables the node to contact other nodes in parallel.
