### PR TITLE
format json for readability when writing libp2p pk to config

### DIFF
--- a/external/libp2p-service.js
+++ b/external/libp2p-service.js
@@ -63,7 +63,7 @@ class Libp2pService {
                 if (!configFile.network.privateKey) {
                     const id = await PeerId.create({bits: 1024, keyType: 'RSA'})
                     configFile.network.privateKey = id.toJSON().privKey;
-                    fs.writeFileSync('.origintrail_noderc', JSON.stringify(configFile));
+                    fs.writeFileSync('.origintrail_noderc', JSON.stringify(configFile, null, 2));
                 }
                 this.config.privateKey = configFile.network.privateKey;
                 this.config.peerId = await PeerId.createFromPrivKey(this.config.privateKey);


### PR DESCRIPTION
Fixes #

Libp2pService minifies the .origintrail_noderc json during initialization when it injects the peer id private key.  This makes it difficult to manually edit the file.

## Proposed Changes

Use the stringify() overload to structure for readability (aka pretty print).
