### PR TITLE
V6/develop Fix issue with installer readme pointing to wrong branch

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -14,7 +14,7 @@ Get this file into the /root directory on the server. Just leave it as a zip fil
 
 **If the repo is not cloned yet:**
 ```
-apt install git -y && cd /root && git clone https://github.com/OriginTrail/ot-node && cd ot-node && git checkout v6/release/testnet && installer/installer.sh
+apt install git -y && cd /root && git clone https://github.com/OriginTrail/ot-node && cd ot-node && git checkout v6/develop && installer/installer.sh
 ```
 
 **If you have already cloned the ot-node repo:**


### PR DESCRIPTION
Fixes #

Changed the readme directions to reflect the installers now in the v6/develop branch.

The directions "**If the repo is not cloned yet:**" are currently broken as it tries to run the installer from the v6/release/testnet branch which doesn't have the installer.