### PR TITLE
V6/develop - apt upgrade hung on input

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -14,7 +14,7 @@ Get this file into the /root directory on the server. Just leave it as a zip fil
 
 **If the repo is not cloned yet:**
 ```
-apt install git -y && cd /root && git clone https://github.com/OriginTrail/ot-node && cd ot-node && git checkout v6/release/testnet && installer/installer.sh
+apt install git -y && cd /root && git clone https://github.com/OriginTrail/ot-node && cd ot-node && git checkout v6/develop && installer/installer.sh
 ```
 
 **If you have already cloned the ot-node repo:**

--- a/installer/README.md
+++ b/installer/README.md
@@ -14,7 +14,7 @@ Get this file into the /root directory on the server. Just leave it as a zip fil
 
 **If the repo is not cloned yet:**
 ```
-apt install git -y && cd /root && git clone https://github.com/OriginTrail/ot-node && cd ot-node && git checkout v6/develop && installer/installer.sh
+apt install git -y && cd /root && git clone https://github.com/OriginTrail/ot-node && cd ot-node && git checkout v6/release/testnet && installer/installer.sh
 ```
 
 **If you have already cloned the ot-node repo:**

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -58,7 +58,7 @@ fi
 
 echo -n "Updating Ubuntu to latest version (may take a few minutes): "
 
-OUTPUT=$(apt upgrade -y >/dev/null 2>&1)
+OUTPUT=$(export DEBIAN_FRONTEND=noninteractive && apt upgrade -y >/dev/null 2>&1)
 
 if [[ $? -ne 0 ]]; then
     echo -e "${RED}FAILED${NC}"


### PR DESCRIPTION
Fixes #

If apt upgrade has local config files change the installer would wait for user input. Installer now accepts all default answers.