### PR TITLE
Configurable GraphDB Options

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -17,6 +17,9 @@
     ],
     "graphDatabase": {
       "name": "node0",
+      "hostname": "localhost",
+      "port": 7200,
+      "ssl" : false,
       "username": "admin",
       "password": ""
     },
@@ -53,6 +56,9 @@
     ],
     "graphDatabase": {
       "name": "node0",
+      "hostname": "localhost",
+      "port": 7200,
+      "ssl" : false,
       "username": "admin",
       "password": ""
     },
@@ -84,6 +90,9 @@
     "blockchain": [],
     "graphDatabase": {
       "name": "node0",
+      "hostname": "localhost",
+      "port": 7200,
+      "ssl" : false,
       "username": "admin",
       "password": ""
     },

--- a/modules/service/data-service.js
+++ b/modules/service/data-service.js
@@ -16,7 +16,11 @@ class DataService {
 
     initialize() {
         this.implementation = new GraphDB({
+            // url: `${this.config.graphDatabase.ssl ? 'https' : 'http'}://${this.config.graphDatabase.hostname}:${this.config.graphDatabase.port}`,
             repositoryName: this.config.graphDatabase.name,
+            hostname: this.config.graphDatabase.hostname,
+            port: this.config.graphDatabase.port,
+            ssl: this.config.graphDatabase.ssl,
             username: this.config.graphDatabase.username,
             password: this.config.graphDatabase.password,
         });


### PR DESCRIPTION
Fixes #
I'm currently running multiple nodes using a central GraphDB with different repositories.
Until now I had to go to the code and change some hardcoded values.

I was not sure which 'style' you prefer, so I added two solutions, which I will comment
## Proposed Changes

  - Add hostname, port and ssl config variables into config.json (TLS defines http:// or https:// , port and host can be changeable)
  - Make data-service initialize the graphDB object with those provided variables
  - Make GraphDB define the url and use it to create the serverconfig
