### PR TITLE
Fix sequelize dialect compatibility problems

### DIFF
--- a/models/commands.js
+++ b/models/commands.js
@@ -25,7 +25,7 @@ module.exports = (sequelize, DataTypes) => {
         status: DataTypes.STRING,
         message: DataTypes.STRING,
         parent_id: DataTypes.UUID,
-        transactional: DataTypes.BOOLEAN,
+        transactional: DataTypes.INTEGER,
         retries: {
             type: DataTypes.INTEGER,
             defaultValue: 0,

--- a/modules/command/command-executor.js
+++ b/modules/command/command-executor.js
@@ -92,7 +92,7 @@ class CommandExecutor {
      * @param command Command
      */
     async _execute(command) {
-        const now = new Date().getTime() / 1000;
+        const now = Math.round(new Date().getTime() / 1000);
         await CommandExecutor._update(command, {
             started_at: now,
         });
@@ -227,7 +227,7 @@ class CommandExecutor {
      * @param insert
      */
     async add(command, delay = 0, insert = true) {
-        const now = new Date().getTime() / 1000;
+        const now = Math.round(new Date().getTime() / 1000);
 
         if (delay != null && delay > constants.MAX_COMMAND_DELAY_IN_MILLS) {
             if (command.ready_at == null) {
@@ -307,7 +307,7 @@ class CommandExecutor {
             command.sequence = command.sequence.slice(1);
         }
         if (!command.ready_at) {
-            command.ready_at = new Date().getTime() / 1000; // take current time
+            command.ready_at = Math.round(new Date().getTime() / 1000); // take current time
         }
         if (command.delay == null) {
             command.delay = 0;


### PR DESCRIPTION
Fixes #
As an experiment I tried swapping out MySQL for PostgreSQL, and discovered two bugs in the process:

1. The _commands_ model requires that some of the Unix time properties (_ready_at_, _started_at_, etc.) be an INTEGER data type, whereas the code is actually generating decimal values with 3 places.  By default MySQL doesn't care - it does the rounding without complaint.  However, other RDB's (e.g. PostgreSQL) throw an error instead.

2. Similarly, the commands model's _transaction_ property needs to be an INTEGER type (see migration file _20211117005500-create-commands.js_ as well as the conversion in _command-executor.js_, line 316).  Again, MySQL does the conversion for free, but PostgreSQL fails and throws an error.

## Proposed Changes

  - Round the Unix time values to zero decimal places after dividing by 1000 to generate a whole integer number.
  - Fix the commands model to make transaction an integer type.

## Benefits

- With these changes it's trivial to swap over to PostgreSQL (should the need arise).  All that's required is changing _username, password, dialect_, and _port_ within _sequelizeConfig.js_  My node is running that way now.
