### PR TITLE
Fix graphdb health check to handle unexisting repo

### DIFF
--- a/external/graphdb-service.js
+++ b/external/graphdb-service.js
@@ -328,19 +328,19 @@ class GraphdbService {
 
     async healthCheck() {
         try {
-            const response = await axios.get('http://localhost:7200/repositories/node0/health', {},
+            const response = await axios.get('http://localhost:7200/', {},
                 {
                     auth: {
                         username: this.config.username,
                         password: this.config.password,
                     },
                 });
-            if (response.data.status === 'green') {
-                return true;
-            }
-            return false;
+            return true;
         } catch (e) {
-            return false;
+            if (e.code === 'ECONNREFUSED') {
+                return false;
+            }
+            return true;
         }
     }
 

--- a/external/graphdb-service.js
+++ b/external/graphdb-service.js
@@ -328,19 +328,24 @@ class GraphdbService {
 
     async healthCheck() {
         try {
-            const response = await axios.get('http://localhost:7200/', {},
+            const response = await axios.get(`http://localhost:7200/repositories/${this.config.repositoryName}/health`, {},
                 {
                     auth: {
                         username: this.config.username,
                         password: this.config.password,
                     },
                 });
-            return true;
-        } catch (e) {
-            if (e.code === 'ECONNREFUSED') {
-                return false;
+            if (response.data.status === 'green') {
+                return true;
             }
-            return true;
+            return false;
+        } catch (e) {
+            if (e.response && e.response.status === 404) {
+                // Expected error: GraphDB is up but has not created node0 repository
+                // Ot-node will create repo in initialization
+                return true;
+            }
+            return false;
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origintrail_node",
-  "version": "6.0.0-beta.1.19",
+  "version": "6.0.0-beta.1.20",
   "description": "OTNode v6 Beta 1",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Fixes

- Handle unexisting graphdb repo situation
- if graphdb is not started returns error with code ECCONREFUSED
- if it is up, returns 406
