### PR TITLE
Remove file type from publishing keywords and set telemetry plugin version

### DIFF
--- a/modules/controller/rpc-controller.js
+++ b/modules/controller/rpc-controller.js
@@ -142,7 +142,15 @@ class RpcController {
         this.app.post('/publish', async (req, res, next) => {
             if (!req.files || !req.files.file || !req.body.assets) {
                 return next({code: 400, message: 'File, assets, and keywords are required fields.'});
+            } else {
+                if(!this.isArrayOfStrings(req.body.assets)){
+                    return next({code: 400, message: `Assets must be a non-empty array of strings, all strings must have double quotes.`});
+                }
+                if(req.body.keywords && !this.isArrayOfStrings(req.body.keywords)) {
+                    return next({code: 400, message: `Keywords must be a non-empty array of strings, all strings must have double quotes.`});
+                }
             }
+
             const operationId = uuidv1();
             try {
                 this.logger.emit({
@@ -768,6 +776,18 @@ class RpcController {
                 return next({code: 400, message: `Error while fetching node info: ${e}. ${e.stack}`});
             }
         });
+    }
+
+    isArrayOfStrings(arr) {
+        try {
+            const bodyAssets = JSON.parse(arr.toLowerCase());
+            if (!(Array.isArray(bodyAssets)) | !(bodyAssets.length > 0) | !bodyAssets.every(i => (typeof i === "string")) | bodyAssets[0] === "") {
+                return false;
+            }
+        } catch (e) {
+            return false;
+        }
+        return true;
     }
 }
 

--- a/modules/service/publish-service.js
+++ b/modules/service/publish-service.js
@@ -22,7 +22,9 @@ class PublishService {
         assertion.id = this.validationService.calculateHash(assertion.metadataHash + assertion.metadata.dataHash);
         assertion.signature = this.validationService.sign(assertion.id);
 
-        keywords.push(assertion.metadata.type);
+        if (assertion.metadata.type !== 'default') {
+            keywords.push(assertion.metadata.type);
+        }
         keywords = [...new Set(keywords.concat(rawAssets))];
 
         const assets = [];

--- a/modules/service/publish-service.js
+++ b/modules/service/publish-service.js
@@ -22,9 +22,6 @@ class PublishService {
         assertion.id = this.validationService.calculateHash(assertion.metadataHash + assertion.metadata.dataHash);
         assertion.signature = this.validationService.sign(assertion.id);
 
-        if (assertion.metadata.type !== 'default') {
-            keywords.push(assertion.metadata.type);
-        }
         keywords = [...new Set(keywords.concat(rawAssets))];
 
         const assets = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origintrail_node",
-  "version": "6.0.0-beta.1.21",
+  "version": "6.0.0-beta.1.22",
   "description": "OTNode v6 Beta 1",
   "main": "index.js",
   "scripts": {
@@ -76,7 +76,7 @@
     "mysql2": "^2.3.3",
     "n3": "^1.12.2",
     "nodemon": "^2.0.15",
-    "ot-telemetry-collector": "^1.0.1",
+    "ot-telemetry-collector": "^1.0.2",
     "p-iteration": "^1.1.8",
     "peer-id": "^0.15.3",
     "pino": "^7.5.1",


### PR DESCRIPTION
# Fixes
- Remove file type from publishing keywords
- Set telemetry plugin version 1.0.2 as required

# Proposed Changes
  - Bump the version for the release
