### PR TITLE
Add body-parser to rpc-controller to allow JSON request bodies

### DIFF
--- a/modules/controller/rpc-controller.js
+++ b/modules/controller/rpc-controller.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const fileUpload = require('express-fileupload');
+const bodyParser = require('body-parser')
 const ipfilter = require('express-ipfilter').IpFilter;
 const fs = require('fs');
 const https = require('https');
@@ -32,6 +33,8 @@ class RpcController {
         this.app.use(fileUpload({
             createParentPath: true,
         }));
+
+        this.app.use(bodyParser.json())
     }
 
     async initialize() {
@@ -590,7 +593,8 @@ class RpcController {
                     }
                 }
 
-                const nquads = JSON.parse(req.body.nquads);
+                const nquads = req.body.nquads instanceof Array
+                    ? req.body.nquads : JSON.parse(req.body.nquads);
 
                 const result = [];
                 if (!assertions || assertions.length === 0) {

--- a/modules/controller/rpc-controller.js
+++ b/modules/controller/rpc-controller.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const fileUpload = require('express-fileupload');
-const bodyParser = require('body-parser')
 const ipfilter = require('express-ipfilter').IpFilter;
 const fs = require('fs');
 const https = require('https');
@@ -27,14 +26,13 @@ class RpcController {
         this.commandExecutor = ctx.commandExecutor;
         this.fileService = ctx.fileService;
         this.app = express();
+        this.app.use(express.json())
 
         this.enableSSL();
 
         this.app.use(fileUpload({
             createParentPath: true,
         }));
-
-        this.app.use(bodyParser.json())
     }
 
     async initialize() {


### PR DESCRIPTION
## Proposed Changes

  - Allow the use of a raw JSON request body for the query and proofs requests, as opposed to multipart/form-data only.

