### PR TITLE
Fix compatibility issues with old versions 

### DIFF
--- a/external/blazegraph-service.js
+++ b/external/blazegraph-service.js
@@ -133,7 +133,7 @@ class BlazegraphService {
             nquads = nquads.toString();
             nquads = nquads.split('\n');
             nquads = nquads.filter((x) => x !== '');
-            await this.transformBlankNodes(nquads);
+            nquads = await this.transformBlankNodes(nquads);
         } else {
             nquads = null;
         }
@@ -157,13 +157,14 @@ class BlazegraphService {
 
         // Transform blank nodes, example: _:t145 -> _:c14n3
         let bnName;
-        for (let nquad of nquads) {
+        for (const nquadIndex in nquads) {
+            const nquad = nquads[nquadIndex];
             if (nquad.includes('_:t')) {
                 const blankNodes = nquad.split(' ').filter((s) => s.includes('_:t'));
                 for (const bn of blankNodes) {
                     const bnValue = Number(bn.substring(3));
                     bnName = `_:c14n${bnValue - minimumBlankNodeValue}`;
-                    nquad = nquad.replace(bn, bnName);
+                    nquads[nquadIndex] = nquad.replace(bn, bnName);
                 }
             }
         }

--- a/external/blazegraph-service.js
+++ b/external/blazegraph-service.js
@@ -131,7 +131,7 @@ class BlazegraphService {
 
         if (nquads.length) {
             nquads = nquads.toString();
-            nquads = nquads.replace(/_:t\d+/gm, '_:c14n$1');
+            nquads = nquads.replace(/_:t(\d+)/gm, '_:c14n$1');
             nquads = nquads.split('\n');
             nquads = nquads.filter((x) => x !== '');
         } else {

--- a/external/blazegraph-service.js
+++ b/external/blazegraph-service.js
@@ -131,7 +131,7 @@ class BlazegraphService {
 
         if (nquads.length) {
             nquads = nquads.toString();
-            nquads = nquads.replace(/_:genid(.){37}/gm, '_:$1');
+            nquads = nquads.replace(/_:t\d+/gm, '_:c14n0');
             nquads = nquads.split('\n');
             nquads = nquads.filter((x) => x !== '');
         } else {

--- a/external/blazegraph-service.js
+++ b/external/blazegraph-service.js
@@ -131,7 +131,7 @@ class BlazegraphService {
 
         if (nquads.length) {
             nquads = nquads.toString();
-            nquads = nquads.replace(/_:t\d+/gm, '_:c14n0');
+            nquads = nquads.replace(/_:t\d+/gm, '_:c14n$1');
             nquads = nquads.split('\n');
             nquads = nquads.filter((x) => x !== '');
         } else {

--- a/external/libp2p-service.js
+++ b/external/libp2p-service.js
@@ -173,9 +173,9 @@ class Libp2pService {
                 if (!async) {
                     const result = await handler(data);
                     this.logger.info(`Sending response from ${this.config.id} to ${handlerProps.connection.remotePeer._idB58String}: event=${eventName};`);
-
+                    const stringifiedData = await this.workerPool.exec('JSONStringify', [data]);
                     await pipe(
-                        [JSON.stringify(result)],
+                        [Buffer.from(stringifiedData)],
                         stream,
                     )
                 } else {

--- a/external/libp2p-service.js
+++ b/external/libp2p-service.js
@@ -223,6 +223,10 @@ class Libp2pService {
             },
         )
 
+        if(response.toString() === 'ack') {
+            return null;
+        }
+
         return JSON.parse(response);
     }
 

--- a/external/libp2p-service.js
+++ b/external/libp2p-service.js
@@ -173,7 +173,7 @@ class Libp2pService {
                 if (!async) {
                     const result = await handler(data);
                     this.logger.info(`Sending response from ${this.config.id} to ${handlerProps.connection.remotePeer._idB58String}: event=${eventName};`);
-                    const stringifiedData = await this.workerPool.exec('JSONStringify', [data]);
+                    const stringifiedData = await this.workerPool.exec('JSONStringify', [result]);
                     await pipe(
                         [Buffer.from(stringifiedData)],
                         stream,

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -1,5 +1,6 @@
 exports.GS1EPCIS = 'gs1-epcis';
 exports.ERC721 = 'erc721';
+exports.OTTELEMETRY = 'ottelemetry';
 exports.MERKLE_TREE = 'Merkle Tree';
 exports.BASIC = 'Basic';
 exports.DID = 'DID';

--- a/modules/controller/rpc-controller.js
+++ b/modules/controller/rpc-controller.js
@@ -199,7 +199,6 @@ class RpcController {
                         id = assertionId;
                     }
                     const result = await this.dataService.resolve(id, true);
-
                     if (result && result.nquads) {
                         let {nquads} = result;
                         let assertion = await this.dataService.createAssertion(nquads);
@@ -229,29 +228,38 @@ class RpcController {
                             this.logger.warn(`Found only ${nodes.length} node(s) for keyword ${id}`);
                         nodes = [...new Set(nodes)];
                         for (const node of nodes) {
-                            const result = await this.queryService.resolve(id, req.query.load, isAsset, node);
-                            if (result) {
-                                const {assertion} = result;
-                                assertion.jsonld.metadata = JSON.parse(sortedStringify(assertion.jsonld.metadata))
-                                assertion.jsonld.data = JSON.parse(sortedStringify(await this.dataService.fromNQuads(assertion.jsonld.data, assertion.jsonld.metadata.type)))
-                                response.push(isAsset ? {
-                                        type: 'asset',
-                                        id: assertion.jsonld.metadata.UALs[0],
-                                        result: {
-                                            metadata: {
-                                                type: assertion.jsonld.metadata.type,
-                                                issuer: assertion.jsonld.metadata.issuer,
-                                                latestState: assertion.jsonld.metadata.timestamp,
-                                            },
-                                            data: assertion.jsonld.data
+                            try {
+                                const result = await this.queryService.resolve(id, req.query.load, isAsset, node);
+                                if (result) {
+                                    const {assertion} = result;
+                                    assertion.jsonld.metadata = JSON.parse(sortedStringify(assertion.jsonld.metadata))
+                                    assertion.jsonld.data = JSON.parse(sortedStringify(await this.dataService.fromNQuads(assertion.jsonld.data, assertion.jsonld.metadata.type)))
+                                    response.push(isAsset ? {
+                                            type: 'asset',
+                                            id: assertion.jsonld.metadata.UALs[0],
+                                            result: {
+                                                metadata: {
+                                                    type: assertion.jsonld.metadata.type,
+                                                    issuer: assertion.jsonld.metadata.issuer,
+                                                    latestState: assertion.jsonld.metadata.timestamp,
+                                                },
+                                                data: assertion.jsonld.data
+                                            }
+                                        } : {
+                                            type: 'assertion',
+                                            id: id,
+                                            assertion: assertion.jsonld
                                         }
-                                    } : {
-                                        type: 'assertion',
-                                        id: id,
-                                        assertion: assertion.jsonld
-                                    }
-                                );
-                                break;
+                                    );
+                                    break;
+                                }
+                            } catch (e) {
+                                this.logger.error({
+                                    msg: `Error while resolving data from another node: ${e.message}. ${e.stack}`,
+                                    Event_name: constants.ERROR_TYPE.RESOLVE_ROUTE_ERROR,
+                                    Event_value1: e.message,
+                                    Id_operation: operationId,
+                                });
                             }
                         }
                     }
@@ -578,7 +586,8 @@ class RpcController {
                 for (const assertionId of assertions) {
                     const content = await this.dataService.resolve(assertionId);
                     if (content) {
-                        const { nquads } = await this.dataService.createAssertion(content.nquads);
+                        const rawNquads = content.nquads ? content.nquads : content.rdf;
+                        const { nquads } = await this.dataService.createAssertion(rawNquads);
                         const proofs = await this.validationService.getProofs(nquads, reqNquads);
                         result.push({ assertionId, proofs });
                     }

--- a/modules/service/data-service.js
+++ b/modules/service/data-service.js
@@ -3,7 +3,6 @@ const N3 = require('n3');
 const constants = require('../constants');
 const GraphDB = require('../../external/graphdb-service');
 const Blazegraph = require('../../external/blazegraph-service');
-const axios = require('axios');
 
 class DataService {
     constructor(ctx) {
@@ -403,9 +402,14 @@ class DataService {
                 };
                 break;
             case this.constants.ERC721:
-                const result = await axios.get(`https://raw.githubusercontent.com/OriginTrail/ot-node/v6/develop/frameDocuments/${this.constants.ERC721}.json`);
-                context = result.data.context;
-                frame = result.data.frame;
+            case this.constants.OTTELEMETRY:
+                context = {
+                    "@context": "https://www.schema.org/"
+                }
+                frame = {
+                    "@context": "https://www.schema.org/",
+                    "@type": type
+                }
                 break;
             default:
                 context = {

--- a/modules/service/data-service.js
+++ b/modules/service/data-service.js
@@ -79,9 +79,14 @@ class DataService {
                     throw new Error(`File format is corrupted, no n-quads extracted.`);
                 }
 
-                let type = assertion.data['@type'];
-                delete assertion.data['@type'];
-                if (!type) {
+                let type;
+                if (assertion.data['@type']) {
+                    type = assertion.data['@type'];
+                    delete assertion.data['@type'];
+                } else if (assertion.data['type']) {
+                    type = assertion.data['type'];
+                    delete assertion.data['type'];
+                }else {
                     type = 'default';
                 }
                 assertion.metadata.type = type;

--- a/modules/service/file-service.js
+++ b/modules/service/file-service.js
@@ -25,14 +25,17 @@ class FileService {
                     reject(err);
                 } else {
                     const fullpath = path.join(directory, filename);
-
-                    fs.writeFile(fullpath, data, (err) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(fullpath);
-                        }
-                    });
+                    try {
+                        fs.writeFile(fullpath, data, (err) => {
+                            if (err) {
+                                reject(err);
+                            } else {
+                                resolve(fullpath);
+                            }
+                        });
+                    } catch (e) {
+                        reject(e);
+                    }
                 }
             });
         });

--- a/modules/service/publish-service.js
+++ b/modules/service/publish-service.js
@@ -85,12 +85,13 @@ class PublishService {
 
     async handleStore(data) {
         if (!data) return false;
-        const {jsonld, nquads} = await this.dataService.createAssertion(data.nquads);
+        const rawNquads = data.nquads ? data.nquads : data.rdf;
+        const { jsonld, nquads } = await this.dataService.createAssertion(rawNquads);
         const status = await this.dataService.verifyAssertion(jsonld, nquads);
 
         // todo check root hash on the blockchain
         if (status) {
-            await this.dataService.insert(data.nquads.join('\n'), `${constants.DID_PREFIX}:${data.id}`);
+            await this.dataService.insert(rawNquads.join('\n'), `${constants.DID_PREFIX}:${data.id}`);
             this.logger.info(`Assertion ${data.id} has been successfully inserted`);
         }
         return status;

--- a/modules/service/publish-service.js
+++ b/modules/service/publish-service.js
@@ -84,14 +84,13 @@ class PublishService {
     }
 
     async handleStore(data) {
-        if (!data) return false;
-        const rawNquads = data.nquads ? data.nquads : data.rdf;
-        const { jsonld, nquads } = await this.dataService.createAssertion(rawNquads);
+        if (!data || data.rdf) return false;
+        const { jsonld, nquads } = await this.dataService.createAssertion(data.nquads);
         const status = await this.dataService.verifyAssertion(jsonld, nquads);
 
         // todo check root hash on the blockchain
         if (status) {
-            await this.dataService.insert(rawNquads.join('\n'), `${constants.DID_PREFIX}:${data.id}`);
+            await this.dataService.insert(data.nquads.join('\n'), `${constants.DID_PREFIX}:${data.id}`);
             this.logger.info(`Assertion ${data.id} has been successfully inserted`);
         }
         return status;

--- a/modules/service/query-service.js
+++ b/modules/service/query-service.js
@@ -118,33 +118,33 @@ class QueryService {
 
         const documentPath = this.fileService.getHandlerIdDocumentPath(handlerId);
         const handlerData = await this.fileService.loadJsonFromFile(documentPath);
+        if (response !== undefined && response.length && handlerData) {
+            for (const object of response) {
+                const assertion = handlerData.find((x) => x.id === object.assertionId);
+                if (assertion) {
+                    if (assertion.nodes.indexOf(object.node) === -1)
+                        assertion.nodes = [...new Set(assertion.nodes.concat(object.node))]
+                } else {
+                    if (!object || !object.nquads)
+                        continue
+                    const rawNquads = object.nquads ? object.nquads : object.rdf;
+                    const assertion = await this.dataService.createAssertion(rawNquads);
 
-        for (const object of response) {
-            const assertion = handlerData.find((x) => x.id === object.assertionId);
-            if (assertion) {
-                if (assertion.nodes.indexOf(object.node) === -1)
-                    assertion.nodes = [...new Set(assertion.nodes.concat(object.node))]
-            } else {
-                if (!object || !object.nquads)
-                    continue
-                const rawNquads = object.nquads ? object.nquads : object.rdf;
-                const assertion = await this.dataService.createAssertion(rawNquads);
-
-                handlerData.push({
-                    id: assertion.jsonld.id,
-                    metadata: assertion.jsonld.metadata,
-                    signature: assertion.jsonld.signature,
-                    nodes: [object.node]
-                })
+                    handlerData.push({
+                        id: assertion.jsonld.id,
+                        metadata: assertion.jsonld.metadata,
+                        signature: assertion.jsonld.signature,
+                        nodes: [object.node]
+                    })
+                }
             }
+
+            await this.fileService.writeContentsToFile(
+                this.fileService.getHandlerIdCachePath(),
+                handlerId,
+                JSON.stringify(handlerData),
+            );
         }
-
-
-        await this.fileService.writeContentsToFile(
-            this.fileService.getHandlerIdCachePath(),
-            handlerId,
-            JSON.stringify(handlerData),
-        );
 
         return true;
     }

--- a/modules/service/query-service.js
+++ b/modules/service/query-service.js
@@ -13,8 +13,7 @@ class QueryService {
 
     async resolve(id, load, isAssetRequested, node) {
         let result = await this.networkService.sendMessage('/resolve', id, node);
-
-        if (!result) {
+        if (!result || (Array.isArray(result) && result[0] === "ack")) {
             return null;
         }
 
@@ -27,7 +26,7 @@ class QueryService {
             await this.dataService.insert(rawNquads.join('\n'), `${constants.DID_PREFIX}:${assertion.jsonld.metadata.id}`);
             this.logger.info(`Assertion ${assertion.jsonld.metadata.id} has been successfully inserted`);
         }
-        return status ? {assertion, isAsset} : null;
+        return status ? { assertion, isAsset } : null;
     }
 
     async handleResolve(id) {

--- a/modules/service/query-service.js
+++ b/modules/service/query-service.js
@@ -108,7 +108,7 @@ class QueryService {
 
     async handleSearchAssertions(request) {
         const {query, options, handlerId} = request;
-        let response = await this.dataService.searchAssertions(query, options);
+        let response = await this.dataService.searchAssertions(query, options || {});
         return {response, handlerId};
     }
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "multiformats": "^9.4.7",
     "mysql2": "^2.3.3",
     "n3": "^1.12.2",
-    "ot-telemetry-collector": "^1.0.3",
+    "ot-telemetry-collector": "^1.0.4",
     "p-iteration": "^1.1.8",
     "peer-id": "^0.15.3",
     "pino": "^7.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origintrail_node",
-  "version": "6.0.0-beta.1.23",
+  "version": "6.0.0-beta.1.24",
   "description": "OTNode v6 Beta 1",
   "main": "index.js",
   "scripts": {

--- a/tools/local-network-setup/.bootstrap_origintrail_noderc
+++ b/tools/local-network-setup/.bootstrap_origintrail_noderc
@@ -1,11 +1,13 @@
 {
-  "blockchain":[
+  "blockchain": [
     {
       "blockchainTitle": "Polygon",
       "networkId": "polygon::testnet",
-      "rpcEndpoints": ["https://rpc-mumbai.maticvigil.com/"],
-      "publicKey": "...",
-      "privateKey": "..."
+      "rpcEndpoints": [
+        "https://rpc-mumbai.maticvigil.com/"
+      ],
+      "publicKey": "0xd08eCEFb11C5e767fA196E2010B736155272537e",
+      "privateKey": "8db5ecd44052100b03c8d5fd0221390ea0145868a58971a70e456c90697135ee"
     }
   ],
   "graphDatabase": {
@@ -19,7 +21,7 @@
     "privateKey": "CAAS4QQwggJdAgEAAoGBALOYSCZsmINMpFdH8ydA9CL46fB08F3ELfb9qiIq+z4RhsFwi7lByysRnYT/NLm8jZ4RvlsSqOn2ZORJwBywYD5MCvU1TbEWGKxl5LriW85ZGepUwiTZJgZdDmoLIawkpSdmUOc1Fbnflhmj/XzAxlnl30yaa/YvKgnWtZI1/IwfAgMBAAECgYEAiZq2PWqbeI6ypIVmUr87z8f0Rt7yhIWZylMVllRkaGw5WeGHzQwSRQ+cJ5j6pw1HXMOvnEwxzAGT0C6J2fFx60C6R90TPos9W0zSU+XXLHA7AtazjlSnp6vHD+RxcoUhm1RUPeKU6OuUNcQVJu1ZOx6cAcP/I8cqL38JUOOS7XECQQDex9WUKtDnpHEHU/fl7SvCt0y2FbGgGdhq6k8nrWtBladP5SoRUFuQhCY8a20fszyiAIfxQrtpQw1iFPBpzoq1AkEAzl/s3XPGi5vFSNGLsLqbVKbvoW9RUaGN8o4rU9oZmPFL31Jo9FLA744YRer6dYE7jJMel7h9VVWsqa9oLGS8AwJALYwfv45Nbb6yGTRyr4Cg/MtrFKM00K3YEGvdSRhsoFkPfwc0ZZvPTKmoA5xXEC8eC2UeZhYlqOy7lL0BNjCzLQJBAMpvcgtwa8u6SvU5B0ueYIvTDLBQX3YxgOny5zFjeUR7PS+cyPMQ0cyql8jNzEzDLcSg85tkDx1L4wi31Pnm/j0CQFH/6MYn3r9benPm2bYSe9aoJp7y6ht2DmXmoveNbjlEbb8f7jAvYoTklJxmJCcrdbNx/iCj2BuAinPPgEmUzfQ="
   },
   "ipWhitelist": [
-  "::1",
+    "::1",
     "127.0.0.1"
   ]
 }

--- a/tools/local-network-setup/.bootstrap_origintrail_noderc
+++ b/tools/local-network-setup/.bootstrap_origintrail_noderc
@@ -6,8 +6,8 @@
       "rpcEndpoints": [
         "https://rpc-mumbai.maticvigil.com/"
       ],
-      "publicKey": "0xd08eCEFb11C5e767fA196E2010B736155272537e",
-      "privateKey": "8db5ecd44052100b03c8d5fd0221390ea0145868a58971a70e456c90697135ee"
+      "publicKey": "",
+      "privateKey": ""
     }
   ],
   "graphDatabase": {


### PR DESCRIPTION
## Fixes

- Handle ACK stream message when sync operation fails on all v6 versions
- Parsing Blazegraph blank nodes
- Nodes on newer version not storing data in old format
- Continue resolving data from other nodes if old node returns invalid data
- Add framing document for Ot-Telemetry