### PR TITLE
add rate limiting for DC and fix handleResolve

### DIFF
--- a/external/libp2p-service.js
+++ b/external/libp2p-service.js
@@ -27,7 +27,7 @@ const initializationObject = {
         dht: KadDHT,
     },
     dialer: {
-        dialTimeout: 1e3,
+        dialTimeout: 2e3,
     },
     config: {
         dht: {

--- a/external/libp2p-service.js
+++ b/external/libp2p-service.js
@@ -180,7 +180,7 @@ class Libp2pService {
                     )
                 } else {
                     await pipe(
-                        ['ack'],
+                        [constants.NETWORK_RESPONSES.ACK],
                         stream
                     )
 
@@ -199,7 +199,7 @@ class Libp2pService {
                    Event_name: constants.ERROR_TYPE.LIBP2P_HANDLE_MSG_ERROR,
                 });
                 await pipe(
-                    ['ack'],
+                    [constants.NETWORK_RESPONSES.ACK],
                     stream
                 )
 
@@ -224,7 +224,7 @@ class Libp2pService {
             },
         )
 
-        if(response.toString() === 'ack') {
+        if(response.toString() === constants.NETWORK_RESPONSES.ACK) {
             return null;
         }
 

--- a/modules/command/publish/send-assertion-command.js
+++ b/modules/command/publish/send-assertion-command.js
@@ -44,11 +44,17 @@ class SendAssertionCommand extends Command {
         }
         nodes = [...new Set(nodes)];
 
-        for (const node of nodes) {
-            this.publishService.store({ id: assertion.id, nquads: nquads }, node).catch((e) => {
-                this.handleError(handlerId, e, `Error while sending data with assertion id ${assertion.id} to node ${node._idB58String}. Error message: ${e.message}. ${e.stack}`);
-            });
-        }
+        const storePromises = nodes.map((node) => this.publishService
+            .store({ id: assertion.id, nquads }, node)
+            .catch((e) => {
+                this.handleError(
+                    handlerId,
+                    e,
+                    `Error while sending data with assertion id ${assertion.id} to node ${node._idB58String}. Error message: ${e.message}. ${e.stack}`,
+                );
+            }));
+
+        await Promise.all(storePromises);
 
         await Models.handler_ids.update(
             {

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -76,12 +76,35 @@ exports.BLOCKCHAIN_QUEUE_LIMIT = 25000;
 exports.RESOLVE_MAX_TIME_MILLIS = 3 * 1000;
 
 /**
+ * @constant {number} STORE_MAX_RETRIES
+ * - Maximum number of retries
+ */
+exports.STORE_MAX_RETRIES = 3;
+
+/**
+ * @constant {number} STORE_BUSY_REPEAT_INTERVAL_IN_MILLS
+ * - Wait interval between retries for sending store requests
+ */
+exports.STORE_BUSY_REPEAT_INTERVAL_IN_MILLS = 2 * 1000;
+
+/**
  * @constant {object} TRIPLE_STORE_IMPLEMENTATION -
  *  Names of available triple store implementations
  */
 exports.TRIPLE_STORE_IMPLEMENTATION = {
     BLAZEGRAPH: 'Blazegraph',
     GRAPHDB: 'GraphDB',
+};
+
+/**
+ * @constant {object} NETWORK_RESPONSES -
+ *  Types of known network responses
+ */
+exports.NETWORK_RESPONSES = {
+    TRUE: true,
+    FALSE: false,
+    ACK: 'ack',
+    BUSY: 'busy',
 };
 
 /**

--- a/modules/controller/rpc-controller.js
+++ b/modules/controller/rpc-controller.js
@@ -234,9 +234,8 @@ class RpcController {
                         nodes = [...new Set(nodes)];
                         for (const node of nodes) {
                             try {
-                                const result = await this.queryService.resolve(id, req.query.load, isAsset, node);
-                                if (result) {
-                                    const {assertion} = result;
+                                const assertion = await this.queryService.resolve(id, req.query.load, isAsset, node);
+                                if (assertion) {
                                     assertion.jsonld.metadata = JSON.parse(sortedStringify(assertion.jsonld.metadata))
                                     assertion.jsonld.data = JSON.parse(sortedStringify(await this.dataService.fromNQuads(assertion.jsonld.data, assertion.jsonld.metadata.type)))
                                     response.push(isAsset ? {

--- a/modules/controller/rpc-controller.js
+++ b/modules/controller/rpc-controller.js
@@ -8,6 +8,7 @@ const path = require('path');
 const { v1: uuidv1, v4: uuidv4 } = require('uuid');
 const sortedStringify = require('json-stable-stringify');
 const validator = require('validator');
+const slowDown = require('express-slow-down');
 const Models = require('../../models/index');
 const constants = require('../constants');
 const pjson = require('../../package.json');
@@ -74,7 +75,7 @@ class RpcController {
 
         this.app.use((error, req, res, next) => {
             if (error instanceof IpDeniedError) {
-                return res.status(401).send('Access denied')
+                return res.status(401).send('Access denied');
             }
             return next();
         });
@@ -82,7 +83,13 @@ class RpcController {
         this.app.use((req, res, next) => {
             this.logger.info(`${req.method}: ${req.url} request received`);
             return next();
-        })
+        });
+
+        this.app.use(slowDown({
+            windowMs: 1 * 60 * 1000, // 1 minute
+            delayAfter: 30, // allow 30 requests per 1 minute, then...
+            delayMs: 2 * 1000, // begin adding 2s of delay per request above 30;
+        }));
     }
 
     async initializeErrorMiddleware() {

--- a/modules/service/publish-service.js
+++ b/modules/service/publish-service.js
@@ -1,4 +1,5 @@
 const { v1: uuidv1 } = require('uuid');
+const sleep = require('sleep-async')().Promise;
 const constants = require('../constants');
 
 class PublishService {
@@ -111,7 +112,7 @@ class PublishService {
             && retries < constants.STORE_MAX_RETRIES
         ) {
             retries += 1;
-            await this.sleepForMilliseconds(constants.STORE_BUSY_REPEAT_INTERVAL_IN_MILLS);
+            await sleep.sleep(constants.STORE_BUSY_REPEAT_INTERVAL_IN_MILLS);
             response = await this.networkService.sendMessage('/store', assertion, node);
         }
 
@@ -145,10 +146,6 @@ class PublishService {
         });
 
         return status;
-    }
-
-    async sleepForMilliseconds(milliseconds) {
-        await new Promise((r) => setTimeout(r, milliseconds));
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "express": "^4.17.1",
     "express-fileupload": "^1.2.1",
     "express-ipfilter": "^1.2.0",
+    "express-slow-down": "^1.4.0",
     "fast-sort": "^3.1.1",
     "fastq": "^1.13.0",
     "fs-extra": "^10.0.0",


### PR DESCRIPTION
## Changes

  - DC nodes wait for responses when publishing. For all responses === 'busy', the node will retry the publish. Max retries is set to 3, and frequency of retries is 2 seconds. These 2 variables can be set in constants.
  - Removed unnecessary blockchain request in handleResolve.
