### PR TITLE
Implement OriginTrail node aliases to .bashrc file - installer.sh

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -13,6 +13,19 @@ clear
 
 cd /root
 
+echo -n "Updating .bashrc file with OriginTrail node aliases: "
+if [ -f "$FILE" ]; then
+    echo "alias otnode-start='systemctl start otnode.service'" >> ~/.bashrc
+    echo "alias otnode-stop='systemctl stop otnode.service'" >> ~/.bashrc
+    echo "alias otnode-restart='systemctl restart otnode.service'" >> ~/.bashrc
+    echo "alias otnode-logs='journalctl -u otnode --output cat -f'" >> ~/.bashrc
+    echo "alias otnode-config='nano ~/ot-node/.origintrail_noderc'" >> ~/.bashrc
+    source ~/.bashrc
+    echo -e "${GREEN}SUCCESS${NC}"
+else
+    echo "$FILE does not exist. Proceeding with OriginTrail node installation."
+fi
+
 echo -n "Updating Ubuntu package repository: "
 
 OUTPUT=$(apt update 2>&1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2580,7 +2580,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.4.tgz",
       "integrity": "sha512-VNxjXUCrF3LvbLgwfkTb5LsFvk6pGIn7OBb9x+3o+iJ6mKw0JTUp4chBFc88hi1aspeZGeZG9jAIbpFYPQSLZw==",
-      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       },
@@ -3328,7 +3327,6 @@
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.17.3.tgz",
       "integrity": "sha512-YusrqwiOTTn8058JDa0cv9unbXdIiIgcgI9gXso0ey4WgkFLd3lYlV9rp9n7nDCsYxXsMDTjA4m1h3T348mdlQ==",
       "dev": true,
-      "hasInstallScript": true,
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -5352,7 +5350,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -5398,7 +5395,6 @@
       "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz",
       "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "4.3.0"
       }
@@ -5436,7 +5432,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -5516,7 +5511,6 @@
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
       "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
@@ -5527,7 +5521,6 @@
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
       "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "abstract-leveldown": "^7.2.0",
         "napi-macros": "~2.0.0",
@@ -5610,7 +5603,6 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -5622,7 +5614,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -7491,7 +7482,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
       "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
-      "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0",
@@ -8350,7 +8340,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/microtime/-/microtime-3.0.0.tgz",
       "integrity": "sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==",
-      "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^1.2.0",
         "node-gyp-build": "^3.8.0"
@@ -9156,7 +9145,6 @@
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.15.tgz",
       "integrity": "sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^3.2.7",
@@ -10323,7 +10311,6 @@
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
       "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
-      "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -11088,7 +11075,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-      "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -12740,7 +12726,6 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.2.tgz",
       "integrity": "sha512-TKdwuLboBn7M34RcvVTuQyhvrA8gYKapuVdm0nBP0mnBc7oECOfUQZrY91cefL3/nm64ZyrejSRrhTVdX7NG/A==",
-      "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "nan": "^2.14.2"
@@ -12753,7 +12738,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.6.tgz",
       "integrity": "sha512-hoY0gOf9EkCw+nimK21FVKHUIG1BMqSiRwxB/q3A9yKZOrOI99PP77BxmarDqWz6rG3vVYiBWfhG8z2Tl+7fZA==",
-      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       },
@@ -12873,7 +12857,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/web3/-/web3-1.6.0.tgz",
       "integrity": "sha512-rWpXnO88MiVX5yTRqMBCVKASxc7QDkXZZUl1D48sKlbX4dt3BAV+nVMVUKCBKiluZ5Bp8pDrVCUdPx/jIYai5Q==",
-      "hasInstallScript": true,
       "dependencies": {
         "web3-bzz": "1.6.0",
         "web3-core": "1.6.0",
@@ -12891,7 +12874,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.6.0.tgz",
       "integrity": "sha512-ugYV6BsinwhIi0CsLWINBz4mqN9wR9vNG0WmyEbdECjxcPyr6vkaWt4qi0zqlUxEnYAwGj4EJXNrbjPILntQTQ==",
-      "hasInstallScript": true,
       "dependencies": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
@@ -13383,7 +13365,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.6.0.tgz",
       "integrity": "sha512-ymN0OFL81WtEeSyb+PFpuUv39fR3frGwsZnIg5EVPZvrOIdaDSFcGSLDmafUt0vKSubvLMVYIBOCskRD6YdtEQ==",
-      "hasInstallScript": true,
       "dependencies": {
         "web3-core": "1.6.0",
         "web3-core-method": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5398,6 +5398,7 @@
       "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz",
       "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "4.3.0"
       }
@@ -5435,6 +5436,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -5514,6 +5516,7 @@
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
       "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
@@ -5524,6 +5527,7 @@
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
       "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "abstract-leveldown": "^7.2.0",
         "napi-macros": "~2.0.0",
@@ -5606,6 +5610,7 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -5617,6 +5622,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"


### PR DESCRIPTION
Adding the following aliases for OriginTrail node into .bashrc file:

**otnode-start**: systemctl start otnode.service
**otnode-stop**: systemctl stop otnode.service
**otnode-restart**: systemctl restart otnode.service
**otnode-logs**: journalctl -u otnode --output cat -f
**otnode-config**: nano ~/ot-node/.origintrail_noderc