### PR TITLE
Implement OriginTrail node aliases to .bashrc file - installer.sh

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -13,6 +13,19 @@ clear
 
 cd /root
 
+echo -n "Updating .bashrc file with OriginTrail node aliases: "
+if [ -f "$FILE" ]; then
+    echo "alias otnode-restart='systemctl restart otnode.service'" >> ~/.bashrc
+    echo "alias otnode-stop='systemctl stop otnode.service'" >> ~/.bashrc
+    echo "alias otnode-start='systemctl start otnode.service'" >> ~/.bashrc
+    echo "alias otnode-logs='journalctl -u otnode --output cat -f'" >> ~/.bashrc
+    echo "alias otnode-config='nano ~/ot-node/.origintrail_noderc'" >> ~/.bashrc
+    source ~/.bashrc
+    echo -e "${GREEN}SUCCESS${NC}"
+else
+    echo "$FILE does not exist. Proceeding with OriginTrail node installation."
+fi
+
 echo -n "Updating Ubuntu package repository: "
 
 OUTPUT=$(apt update 2>&1)

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -8,6 +8,7 @@ N1=$'\n'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
+FILE=/root/.bashrc
 
 clear
 


### PR DESCRIPTION
Adding the following aliases for OriginTrail node into .bashrc file:

**otnode-start**: systemctl start otnode.service
**otnode-stop**: systemctl stop otnode.service
**otnode-restart**: systemctl restart otnode.service
**otnode-logs**: journalctl -u otnode --output cat -f
**otnode-config**: nano ~/ot-node/.origintrail_noderc