### PR TITLE
Removed GraphDB install option + install latest NPM version

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 OS_VERSION=$(lsb_release -sr)
-GRAPHDB_FILE=$(ls /root/graphdb*.zip)
-GRAPHDB_DIR=$(echo $GRAPHDB_FILE | sed 's|-dist.zip||')
 OTNODE_DIR="/root/ot-node"
 N1=$'\n'
 GREEN='\033[0;32m'
@@ -65,111 +63,8 @@ if [[ $? -ne 0 ]]; then
 else
     echo -e "${GREEN}SUCCESS${NC}"
 fi
-
-while true; do
-    read -p "Please select the database you would like to use: [1]GraphDB [2]Blazegraph [E]xit: " choice
-    case "$choice" in
-        [1gG]* ) echo -e "GraphDB selected. Proceeding with installation."; DATABASE=graphdb; break;;
-        [2bB]* ) echo -e "Blazegraph selected. Proceeding with installation."; DATABASE=blazegraph; break;;
-        [Ee]* ) echo "Installer stopped by user"; exit;;
-        * ) echo "Please make a valid choice and try again.";;
-    esac
-done
-
-if [[ $DATABASE = "graphdb" ]]; then
     
-    echo -n "Checking that the GraphDB file is present in /root: "
 
-    if [[ ! -f $GRAPHDB_FILE ]]; then
-        echo -e "${RED}FAILED${NC}"
-        echo "The graphdb file needs to be downloaded to /root. Please create an account at https://www.ontotext.com/products/graphdb/graphdb-free/ and click the standalone version link in the email."
-        exit 1
-    else
-        echo -e "${GREEN}SUCCESS${NC}"
-    fi
-
-    echo -n "Unzipping GraphDB: "
-OUTPUT=$(unzip -o $GRAPHDB_FILE >/dev/null 2>&1)
-OUTPUT=$(unzip -o $GRAPHDB_FILE 2>&1)
-
-if [[ $? -ne 0 ]]; then
-    echo -e "${RED}FAILED${NC}"
-    echo "There was an error unzipping GraphDB."
-    echo $OUTPUT
-    exit 1
-else
-    echo -e "${GREEN}SUCCESS${NC}"
-fi
-
-echo -n "Rename GraphDB directory: "
-OUTPUT=$(mv $GRAPHDB_DIR graphdb-free 2>&1)
-
-if [[ $? -ne 0 ]]; then
-    echo -e "${RED}FAILED${NC}"
-    echo "There was an error unzipping GraphDB."
-    echo $OUTPUT
-    exit 1
-else
-    echo -e "${GREEN}SUCCESS${NC}"
-fi
-
-    echo -n "Copying graphdb service file: "
-
-    OUTPUT=$(cp $OTNODE_DIR/installer/data/graphdb.service /lib/systemd/system/ 2>&1)
-
-    if [[ $? -ne 0 ]]; then
-        echo -e "${RED}FAILED${NC}"
-        echo "There was an error copying the graphdb service file."
-        echo $OUTPUT
-        exit 1
-    else
-        echo -e "${GREEN}SUCCESS${NC}"
-    fi
-
-    systemctl daemon-reload
-
-    echo -n "Enable GraphDB service on boot: "
-
-    OUTPUT=$(systemctl enable graphdb 2>&1)
-
-    if [[ $? -ne 0 ]]; then
-        echo -e "${RED}FAILED${NC}"
-        echo "There was an error enabling the GraphDB service."
-        echo $OUTPUT
-        exit 1
-    else
-        echo -e "${GREEN}SUCCESS${NC}"
-    fi
-
-    echo -n "Starting GraphDB: "
-
-    OUTPUT=$(systemctl start graphdb 2>&1)
-
-    if [[ $? -ne 0 ]]; then
-        echo -e "${RED}FAILED${NC}"
-        echo "There was an error starting GraphDB."
-        echo $OUTPUT
-        exit 1
-    else
-        echo -e "${GREEN}SUCCESS${NC}"
-    fi
-
-    echo -n "Confirming GraphDB has started: "
-
-    IS_RUNNING=$(systemctl show -p ActiveState --value graphdb)
-
-    if [[ $IS_RUNNING == "active" ]]; then
-        echo -e "${GREEN}SUCCESS${NC}"
-    else
-        echo -e "${RED}FAILED${NC}"
-        echo "There was an error starting GraphDB."
-        echo $OUTPUT
-        exit 1
-    fi
-fi
-
-if [[ $DATABASE = "blazegraph" ]]; then
-    
     echo -n "Downloading Blazegraph: " 
 
     OUTPUT=$(wget https://github.com/blazegraph/database/releases/latest/download/blazegraph.jar 2>&1)
@@ -236,7 +131,6 @@ if [[ $DATABASE = "blazegraph" ]]; then
         echo $OUTPUT
         exit 1
     fi
-fi
 
 echo -n "Downloading Node.js v16: "
 
@@ -381,7 +275,7 @@ cd ot-node
 
 echo -n "Executing npm install: "
 
-OUTPUT=$(npm install 2>&1)
+OUTPUT=$(npm install -g npm@latest 2>&1)
 if [[ $? -ne 0 ]]; then
     echo -e "${RED}FAILED${NC}"
     echo "There was an error executing npm install."


### PR DESCRIPTION
Tested on my node.

"Due to rapid testnet growth your nodes are most likely stretching GraphDB Free to its limits. All DKG v6 node runners with GraphDB Free as the local triple store, please migrate your node to Blazegraph ASAP"