### PR TITLE
V6 install build-essential (NPM Install fix)

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -66,6 +66,19 @@ else
     echo -e "${GREEN}SUCCESS${NC}"
 fi
 
+echo -n "Installing build-essential: "
+
+OUTPUT=$(apt install build-essential -y 2>&1)
+
+if [[ $? -ne 0 ]]; then
+    echo -e "${RED}FAILED${NC}"
+    echo "There was an error installing build-essential."
+    echo $OUTPUT
+    exit 1
+else
+    echo -e "${GREEN}SUCCESS${NC}"
+fi
+
 while true; do
     read -p "Please select the database you would like to use: [1]GraphDB [2]Blazegraph [E]xit: " choice
     case "$choice" in


### PR DESCRIPTION
Small change to install build essentials to increase compatibility with stock Ubuntu Server 20.04.4 LTS installs, This should make the installer script compatible with the Raspberry Pi 4 (maybe others but only RPi4 4GB tested).

Edit: Upon further testing this should fix the NPM issues people are getting