### PR TITLE
Temporary fix NPM dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint-config-prettier": "^8.5.0",
     "ethereumjs-wallet": "^1.0.2",
     "form-data": "^4.0.0",
-    "ganache": "^7.0.3",
     "husky": "^6.0.0",
     "lint-staged": "^12.3.7",
     "mocha": "^9.2.2",


### PR DESCRIPTION
Removing Ganache to solve NPM dependency problem caused in latest installation. With this temporary fix the installer can be executed and installation of otnode + blazegraph runs smoothly.