### PR TITLE
Change in firewall management

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -451,29 +451,39 @@ else
     echo -e "${GREEN}SUCCESS${NC}"
 fi
 
-echo -n "Opening firewall ports 22,8900,9000: "
 
-OUTPUT=$(ufw allow 22/tcp && ufw allow 8900 && ufw allow 9000 2>&1)
-if [[ $? -ne 0 ]]; then
-    echo -e "${RED}FAILED${NC}"
-    echo "There was an error opening the firewall ports."
-    echo $OUTPUT
-    exit 1
-else
-    echo -e "${GREEN}SUCCESS${NC}"
-fi
+echo  "Fireawll tcp ports 8900(rpc) and 9000(libp2p) needs to be open on wan. You can choose to let the installer do this for you , or skip it and do this yourself:"
+read -r -p "Open ports 8900 and 9000 using ufw or skip this? [Y/n] " yn
+case $yn in
+    [Nn])
+        echo -n "Not opening any ports, you will need to do this yourself"
+	      ;;
 
-echo -n "Enabling the firewall: "
+    *)
+        echo -n "Opening firewall ports 8900,9000: "
+        OUTPUT=$(ufw allow 8900 && ufw allow 9000 2>&1)
+        if [[ $? -ne 0 ]]; then
+            echo -e "${RED}FAILED${NC}"
+            echo "There was an error opening the firewall ports."
+            echo $OUTPUT
+            exit 1
+        else
+            echo -e "${GREEN}SUCCESS${NC}"
+        fi
 
-OUTPUT=$(yes | ufw enable 2>&1)
-if [[ $? -ne 0 ]]; then
-    echo -e "${RED}FAILED${NC}"
-    echo "There was an error enabling the firewall."
-    echo $OUTPUT
-    exit 1
-else
-    echo -e "${GREEN}SUCCESS${NC}"
-fi
+        echo -n "Enabling the firewall: "
+
+        OUTPUT=$(yes | ufw enable 2>&1)
+        if [[ $? -ne 0 ]]; then
+            echo -e "${RED}FAILED${NC}"
+            echo "There was an error enabling the firewall."
+            echo $OUTPUT
+            exit 1
+        else
+            echo -e "${GREEN}SUCCESS${NC}"
+        fi
+        ;;
+esac
 
 echo -n "Adding NODE_ENV=testnet to .env: "
 


### PR DESCRIPTION
Added an Y/N query if user want to sort the firewall or have it done automatically using ufw. Also removed the opening of port 22, think it's none of our business how the node operators access their servers

## Fixes  
1.  Installer will not open port 22 from "any host" (How the user accesses the machine is none of our business?)
2. Ufw is a dependency we can avoid

# Description
Personally I think nobody should mess with the firewall rules unless user clearly opted in to do so. 
My main problem with the current code was that its a bit aggressive to open port 22 automatically from "any host to any ip", people might  have servers secured in all types of way. 

Also some users might for example prefer iptables to ufw - thats the reason for the Y/N query. Its a bit aggressive to automatically do "ufw enable" without user opting in.  


