### PR TITLE
Added mariadb support, bug fix, several checks for node reinstallation

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -6,7 +6,7 @@ BRANCH_DIR="/root/ot-node-6-release-testnet"
 OTNODE_DIR="/root/ot-node"
 FUSEKI_VER="apache-jena-fuseki-4.5.0"
 NODEJS_VER="16"
-FILE=/root/.bashrc
+BASHRC_FILE=/root/.bashrc
 
 text_color() {
     GREEN='\033[0;32m'
@@ -39,8 +39,8 @@ perform_step() {
 }
 
 install_aliases() {
-    if [ -f "$FILE" ]; then
-        if grep -Fxq "alias otnode-restart='systemctl restart otnode.service'" $FILE; then
+    if [ -f "$BASHRC_FILE" ]; then
+        if grep -Fxq "alias otnode-restart='systemctl restart otnode.service'" $BASHRC_FILE; then
             echo "Aliases found, skipping."
         else
             echo "alias otnode-restart='systemctl restart otnode.service'" >> ~/.bashrc
@@ -49,69 +49,85 @@ install_aliases() {
             echo "alias otnode-logs='journalctl -u otnode --output cat -f'" >> ~/.bashrc
             echo "alias otnode-config='nano ~/ot-node/.origintrail_noderc'" >> ~/.bashrc
             source ~/.bashrc
-            text_color $GREEN OK
         fi
     else
-        echo "$FILE does not exist. Proceeding with OriginTrail node installation."
+        echo "$BASHRC_FILE does not exist. Proceeding with OriginTrail node installation."
     fi
 }
 
 install_directory() {
+    #Download new version .zip file
+    #Unpack to init folder
+    perform_step wget https://$ARCHIVE_REPOSITORY_URL/$BRANCH.zip "Downloading node files"
+    perform_step unzip *.zip "Unzipping node files"
+    rm *.zip
     OTNODE_VERSION=$(jq -r '.version' $BRANCH_DIR/package.json)
-
     mkdir $OTNODE_DIR
     mkdir $OTNODE_DIR/$OTNODE_VERSION
-
+    shopt -s dotglob
     mv $BRANCH_DIR/* $OTNODE_DIR/$OTNODE_VERSION/
-    mv $BRANCH_DIR/.* $OTNODE_DIR/$OTNODE_VERSION/
-
-    rm -r $BRANCH_DIR
-
-    ln -sfn $OTNODE_DIR/$OTNODE_VERSION $OTNODE_DIR/current
+    rm -rf $BRANCH_DIR
+    perform_step ln -sfn $OTNODE_DIR/$OTNODE_VERSION $OTNODE_DIR/current "Configuring node directory"
 }
 
 install_firewall() {
-    ufw allow 22/tcp && ufw allow 8900 && ufw allow 9000
+    ufw allow 22/tcp
+    ufw allow 8900
+    ufw allow 9000
     yes | ufw enable
 }
 
 install_fuseki() {
-    wget https://dlcdn.apache.org/jena/binaries/$FUSEKI_VER.zip
-    unzip $FUSEKI_VER.zip
-
+    perform_step wget https://dlcdn.apache.org/jena/binaries/$FUSEKI_VER.zip "Downloading Fuseki"
+    perform_step unzip $FUSEKI_VER.zip "Unzipping Fuseki"
     rm /root/$FUSEKI_VER.zip
     mkdir /root/fuseki
     mkdir /root/fuseki/tdb
     cp /root/$FUSEKI_VER/fuseki-server.jar /root/fuseki/
     cp -r /root/$FUSEKI_VER/webapp/ /root/fuseki/
     rm -r /root/$FUSEKI_VER
-
-    perform_step cp $OTNODE_DIR/installer/data/fuseki.service /lib/systemd/system/
-
+    perform_step cp $OTNODE_DIR/installer/data/fuseki.service /lib/systemd/system/ "Copying Fuseki service file"
     systemctl daemon-reload
-    systemctl enable fuseki
-    systemctl start fuseki
-    systemctl status fuseki
+    perform_step systemctl enable fuseki "Enabling Fuseki"
+    perform_step systemctl start fuseki "Starting Fuseki"
+    perform_step systemctl status fuseki "Fuseki status"
 }
 
 install_blazegraph() {
-    wget https://github.com/blazegraph/database/releases/latest/download/blazegraph.jar
-    cp $OTNODE_DIR/installer/data/blazegraph.service /lib/systemd/system/
-
+    perform_step wget https://github.com/blazegraph/database/releases/latest/download/blazegraph.jar "Downloading Blazegraph"
+    perform_step cp $OTNODE_DIR/installer/data/blazegraph.service /lib/systemd/system/ "Copying Blazegraph service file"
     systemctl daemon-reload
-    systemctl enable blazegraph
-    systemctl start blazegraph
-    systemctl status blazegraph
+    perform_step systemctl enable blazegraph "Enabling Blazegrpah"
+    perform_step systemctl start blazegraph "Starting Blazegraph"
+    perform_step systemctl status blazegraph "Blazegraph status"
 }
 
-install_mysql() {
+install_sql() {
+    while true; do
+        read -p "Please select the SQL you would like to use: [1]MySQL [2]MariaDB [E]xit " choice
+        case "$choice" in
+            [1]* )  text_color $GREEN "MySQL selected. Proceeding with installation."
+                    sql=mysql
+                    export DEBIAN_FRONTEND=noninteractive
+                    perform_step apt-get install mysql-server -y "Installing mysql-server"
+                    break;;
+            [2]* )  text_color $GREEN "MariaDB selected. Proceeding with installation."
+                    sql=mariadb
+                    export DEBIAN_FRONTEND=noninteractive
+                    perform_step apt-get install mariadb-server -y "Installing mariadb-server"
+                    break;;
+            [Ee]* ) text_color $RED "Installer stopped by user"; exit;;
+            * )     text_color $YELLOW "Please make a valid choice and try again.";;
+        esac
+    done
+
     if [ -d "/var/lib/mysql/operationaldb/" ]; then
     #check if operationaldb already exists
         text_color $YELLOW "Old sql database detected. Please enter your sql password to overwrite it."
         for x in {1..5}; do
             read -p "Enter your sql repository password (leave blank if none): " password
             echo -n "Deleting old sql database: "
-            OUTPUT=$(MYSQL_PWD=$password mysql -u root -e "DROP DATABASE IF EXISTS operationaldb;" 2>&1)     
+            OUTPUT=$(MYSQL_PWD=$password $sql -u root -e "DROP DATABASE IF EXISTS operationaldb;" 2>&1)     
             if [[ $? -ne 0 ]]; then
                 text_color $RED "FAILED"
                 echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
@@ -123,7 +139,7 @@ install_mysql() {
                         read -p "Enter a new sql repository password if you wish (do not leave blank): " password
                         if [ -n "$password" ]; then
                             echo -n "Configuring new sql password: "
-                            OUTPUT=$(mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$password';" 2>&1)
+                            OUTPUT=$($sql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$password';" 2>&1)
                             if [[ $? -ne 0 ]]; then
                                 text_color $RED "FAILED"
                                 echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
@@ -145,13 +161,13 @@ install_mysql() {
             fi
         done
     else
-        OUTPUT=$(mysql -u root -e "status;" 2>&1)
+        OUTPUT=$($sql -u root -e "status;" 2>&1)
         #check if sql is password protected
         if [[ $? -ne 0 ]]; then
             for y in {1..5}; do
                 read -p "Enter your sql repository password: " password
                 echo -n "Password check: "
-                OUTPUT=$(MYSQL_PWD=$password mysql -u root -e "status;" 2>&1)
+                OUTPUT=$(MYSQL_PWD=$password $sql -u root -e "status;" 2>&1)
                 #check whether entered password matches current sql password
                 if [[ $? -ne 0 ]]; then
                     text_color $YELLOW "ERROR - The sql password provided does not match your current sql password. Please try again ($y/5)"
@@ -171,7 +187,7 @@ install_mysql() {
                 if [ -n "$password" ]; then
                 #if password isn't blank
                     echo -n "Configuring new sql password: "
-                    OUTPUT=$(mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$password';" 2>&1)
+                    OUTPUT=$($sql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$password';" 2>&1)
                     if [[ $? -ne 0 ]]; then
                         text_color $RED "FAILED"
                         echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
@@ -189,7 +205,7 @@ install_mysql() {
 
     echo "REPOSITORY_PASSWORD=$password" > $OTNODE_DIR/.env
     echo -n "Creating new sql database: "
-    OUTPUT=$(MYSQL_PWD=$password mysql -u root -e "CREATE DATABASE operationaldb /*\!40100 DEFAULT CHARACTER SET utf8 */;" 2>&1)
+    OUTPUT=$(MYSQL_PWD=$password $sql -u root -e "CREATE DATABASE operationaldb /*\!40100 DEFAULT CHARACTER SET utf8 */;" 2>&1)
     if [[ $? -ne 0 ]]; then
         text_color $RED "FAILED"
         echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
@@ -197,34 +213,42 @@ install_mysql() {
     else
         text_color $GREEN "OK"
     fi
-    perform_step sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting max log size"
-    perform_step sed -i '/disable_log_bin/a wait_timeout = 31536000' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting wait timeout"
-    perform_step sed -i 'sed -i '/disable_log_bin/a interactive_timeout = 31536000' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting interactive timeout"
-
-    echo "disable_log_bin" >> /etc/mysql/mysql.conf.d/mysqld.cnf
-    systemctl restart mysql
+    
+    if [ $sql = mysql ]; then
+        perform_step sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting max log size"
+        echo "disable_log_bin" >> /etc/mysql/mysql.conf.d/mysqld.cnf
+        perform_step sed -i '/disable_log_bin/a wait_timeout = 31536000' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting wait timeout"
+        perform_step sed -i '/disable_log_bin/a interactive_timeout = 31536000' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting interactive timeout"
+    fi
+    if [ $sql = mariadb ]; then
+        perform_step sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mariadb.conf.d/50-server.cnf "Setting max log size"
+        echo "disable_log_bin" >> /etc/mysql/mariadb.conf.d/50-server.cnf
+        perform_step sed -i '/disable_log_bin/a wait_timeout = 31536000' /etc/mysql/mariadb.conf.d/50-server.cnf "Setting wait timeout"
+        perform_step sed -i '/disable_log_bin/a interactive_timeout = 31536000' /etc/mysql/mariadb.conf.d/50-server.cnf "Setting interactive timeout"
+    fi
+    perform_step systemctl restart $sql "Restarting $sql"
 }
 
 install_node() {
     # Change directory to ot-node/current
     cd $OTNODE_DIR
 
-    npm ci --omit=dev --ignore-scripts "Executing npm ci --omit=dev --ignore-scripts"
+    perform_step npm ci --omit=dev --ignore-scripts "Executing npm ci --omit=dev --ignore-scripts"
 
     echo "NODE_ENV=testnet" >> $OTNODE_DIR/.env
 
-    touch $CONFIG_DIR/.origintrail_noderc
+    perform_step touch $CONFIG_DIR/.origintrail_noderc "Configuring node config file"
     jq --null-input --arg tripleStore "$tripleStore" '{"logLevel": "trace", "auth": {"ipWhitelist": ["::1", "127.0.0.1"]}, "modules": {"tripleStore":{"defaultImplementation": $tripleStore}}}' > $CONFIG_DIR/.origintrail_noderc
 
     jq --arg blockchain "otp" --arg evmOperationalWallet "$EVM_OPERATIONAL_WALLET" --arg evmOperationalWalletPrivateKey "$EVM_OPERATIONAL_PRIVATE_KEY" --arg evmManagementWallet "$EVM_MANAGEMENT_WALLET" '.modules.blockchain.implementation[$blockchain].config |= { "evmOperationalWalletPublicKey": $evmOperationalWallet, "evmOperationalWalletPrivateKey": $evmOperationalWalletPrivateKey, "evmManagementWalletPublicKey": $evmManagementWallet} + .' $CONFIG_DIR/.origintrail_noderc > $CONFIG_DIR/origintrail_noderc_tmp
     mv $CONFIG_DIR/origintrail_noderc_tmp $CONFIG_DIR/.origintrail_noderc
 
-    cp $OTNODE_DIR/installer/data/otnode.service /lib/systemd/system/
+    perform_step cp $OTNODE_DIR/installer/data/otnode.service /lib/systemd/system/ "Copying otnode service file"
     
     systemctl daemon-reload
-    systemctl enable otnode
-    systemctl start otnode
-    systemctl status otnode
+    perform_step systemctl enable otnode "Enabling otnode"
+    perform_step systemctl start otnode "Starting otnode"
+    perform_step systemctl status otnode "otnode status"
 }
 
 clear
@@ -235,29 +259,39 @@ header_color $BGREEN "Welcome to the OriginTrail Installer. Please sit back whil
 
 header_color $BGREEN "Installing OriginTrail node pre-requisites..."
 
+export DEBIAN_FRONTEND=noninteractive
 perform_step install_aliases "Updating .bashrc file with OriginTrail node aliases"
-perform_step rm /var/lib/dpkg/lock-frontend "Removing any frontend locks"
+perform_step rm -rf /var/lib/dpkg/lock-frontend "Removing any frontend locks"
 perform_step apt update "Updating Ubuntu package repository"
-perform_step export DEBIAN_FRONTEND=noninteractive "Updating Ubuntu to latest version 1/2"
-perform_step apt upgrade -y "Updating Ubuntu to latest version 2/2"
-perform_step apt install default-jre unzip jq -y "Installing default-jre, unzip, jq"
-perform_step apt install build-essential -y "Installing build-essential"
-perform_step wget https://$ARCHIVE_REPOSITORY_URL/$BRANCH.zip "Downloading ot-node"
-perform_step unzip *.zip "Unzipping ot-node"
-perform_step rm *.zip "Removing zip file"
-#Download new version .zip file
-#Unpack to init folder
+perform_step apt upgrade -y "Updating Ubuntu to latest version"
+perform_step apt install default-jre unzip jq build-essential -y "Installing default-jre, unzip, jq"
 perform_step wget https://deb.nodesource.com/setup_$NODEJS_VER.x "Downloading Node.js v$NODEJS_VER"
 chmod +x setup_$NODEJS_VER.x
 perform_step ./setup_$NODEJS_VER.x "Installing Node.js v$NODEJS_VER"
 rm -rf setup_$NODEJS_VER.x
-perform_step apt update "Updating the Ubuntu repo"
-perform_step apt-get install nodejs -y "Installing node.js"
+perform_step apt update "Updating Ubuntu package repository"
+perform_step apt-get install nodejs tcllib -y "Installing node.js and tcllib"
 perform_step npm install -g npm "Installing npm"
-perform_step apt-get install tcllib mysql-server -y "Installing tcllib and mysql-server"
-perform_step apt remove unattended-upgrades -y "Remove unattended upgrades"
-perform_step install_directory "Assembling ot-node directory"
 perform_step install_firewall "Configuring firewall"
+perform_step apt remove unattended-upgrades -y "Remove unattended upgrades"
+
+
+header_color $BGREEN "Preparing OriginTrail node directory..."
+
+
+if [[ -d "$OTNODE_DIR" ]]; then
+    while true; do
+        read -p "Previous ot-node directory detected. Would you like to overwrite it ? [Y]es [N]o [E]xit " choice
+        case "$choice" in
+        [yY]* ) text_color $GREEN "Reinstalling ot-node directory."; rm -rf $OTNODE_DIR; install_directory; break;;
+        [nN]* ) text_color $GREEN "Keeping previous ot-node directory."; break;;
+        [eE]* ) text_color $RED "Installer stopped by user"; exit;;
+        * )     text_color $YELLOW "Please make a valid choice and try again.";;
+        esac
+    done
+else
+    install_directory
+fi
 
 OTNODE_DIR=$OTNODE_DIR/current
 
@@ -266,16 +300,48 @@ header_color $BGREEN "Installing Triplestore (Graph Database)..."
 while true; do
     read -p "Please select the database you would like to use: [1]Fuseki [2]Blazegraph [E]xit: " choice
     case "$choice" in
-        [1gG]* ) echo -e "Fuseki selected. Proceeding with installation."; tripleStore=ot-fuseki; perform_step install_fuseki "Installing Fuseki"; break;;
-        [2bB]* ) echo -e "Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph; perform_step install_blazegraph "Installing Blazegraph"; break;;
-        [Ee]* ) echo "Installer stopped by user"; exit;;
-        * ) echo "Please make a valid choice and try again.";;
+        [1gG]* ) text_color $GREEN "Fuseki selected. Proceeding with installation."; tripleStore=ot-fuseki; break;;
+        [2bB]* ) text_color $GREEN "Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph; break;;
+        [Ee]* )  text_color $RED "Installer stopped by user"; exit;;
+        * )      text_color $YELLOW "Please make a valid choice and try again.";;
     esac
 done
 
-header_color $BGREEN "Installing MySQL..."
+if [ $tripleStore = "ot-fuseki" ]; then
+    if [ -d "/root/fuseki" ]; then
+        while true; do
+            read -p "Previous Fuseki triplestore detected. Would you like to overwrite it ? [Y]es [N]o [E]xit " choice
+            case "$choice" in
+            [yY]* ) text_color $GREEN "Reinstalling Fuseki."; rm -rf fuseki*; install_fuseki; break;;
+            [nN]* ) text_color $GREEN "Keeping previous Fuseki installation."; break;;
+            [eE]* ) text_color $RED "Installer stopped by user"; exit;;
+            * )     text_color $YELLOW "Please make a valid choice and try again.";;
+            esac
+        done
+    else
+        install_fuseki
+    fi
+fi
 
-install_mysql
+if [ $tripleStore = "ot-blazegraph" ]; then
+    if [ -f "blazegraph.jar" ]; then
+        while true; do
+            read -p "Previous Blazegraph triplestore detected. Would you like to overwrite it ? [Y]es [N]o [E]xit " choice
+            case "$choice" in
+            [yY]* ) text_color $GREEN "Reinstalling Blazegraph."; rm -rf blazegraph*; install_blazegraph; break;;
+            [nN]* ) text_color $GREEN "Keeping old Blazegraph Installation."; break;;
+            [eE]* ) text_color $RED "Installer stopped by user"; exit;;
+            * )     text_color $YELLOW "Please make a valid choice and try again.";;
+            esac
+        done
+    else
+        install_blazegraph
+    fi
+fi
+
+header_color $BGREEN "Installing SQL..."
+
+install_sql
 
 header_color $BGREEN "Configuring OriginTrail node..."
 
@@ -318,7 +384,7 @@ CONFIG_DIR=$OTNODE_DIR/..
     #esac
 #done
 
-perform_step install_node "Configuring ot-node"
+install_node
 
 text_color $GREEN "Logs will be displayed. Press ctrl+c to exit the logs. The node WILL stay running after you return to the command prompt."
 echo ""

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -4,7 +4,7 @@ ARCHIVE_REPOSITORY_URL="github.com/OriginTrail/ot-node/archive"
 BRANCH="v6/release/testnet"
 BRANCH_DIR="/root/ot-node-6-release-testnet"
 OTNODE_DIR="/root/ot-node"
-FUSEKI_VER="apache-jena-fuseki-4.5.0"
+FUSEKI_VER="apache-jena-fuseki-4.6.0"
 NODEJS_VER="16"
 
 text_color() {
@@ -118,17 +118,19 @@ install_blazegraph() {
 }
 
 install_sql() {
-    text_color $YELLOW "IMPORTANT NOTE: to avoid potential migration issues from one SQL to another, please select the one you are currently using. If this is your first installation, both choices are valid. If you don't know the answer, select [1].
+    text_color $YELLOW"IMPORTANT NOTE: to avoid potential migration issues from one SQL to another, please select the one you are currently using. If this is your first installation, both choices are valid. If you don't know the answer, select [1].
     "
     while true; do
         read -p "Please select the SQL you would like to use: (Default: MySQL) [1]MySQL [2]MariaDB [E]xit " choice
         case "$choice" in
-            [2]* )  text_color $GREEN "MariaDB selected. Proceeding with installation."
+            [2]* )  text_color $GREEN"MariaDB selected. Proceeding with installation."
                     sql=mariadb
+                    perform_step apt-get install curl software-properties-common dirmngr ca-certificates apt-transport-https -y "Installing mariadb dependencies"
+                    perform_step curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.8 "Setting mariadb version to 10.8"
                     perform_step apt-get install mariadb-server -y "Installing mariadb-server"
                     break;;
-            [Ee]* ) text_color $RED "Installer stopped by user"; exit;;
-            * )     text_color $GREEN "MySQL selected. Proceeding with installation."
+            [Ee]* ) text_color $RED"Installer stopped by user"; exit;;
+            * )     text_color $GREEN"MySQL selected. Proceeding with installation."
                     sql=mysql
                     mysql_native_password=" WITH mysql_native_password"
                     perform_step apt-get install tcllib mysql-server -y "Installing mysql-server"
@@ -146,7 +148,7 @@ install_sql() {
             if [[ $? -ne 0 ]]; then
                 text_color $RED "FAILED"
                 echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
-                text_color $YELLOW "Wrong password entered. Try again ($x/5)"
+                text_color $YELLOW"Wrong password entered. Try again ($x/5)"
             else
                 text_color $GREEN "OK"
                 if [ -z "$password" ]; then
@@ -164,14 +166,14 @@ install_sql() {
                                 break
                             fi
                         else
-                            text_color $YELLOW "You must enter a sql repository password. Please try again." 
+                            text_color $YELLOW"You must enter a sql repository password. Please try again." 
                         fi
                     done
                 fi
                 break
             fi
             if [ $x == 5 ]; then
-                text_color $RED "FAILED. If you forgot your sql password, you must reset it before attempting this installer again."
+                text_color $RED"FAILED. If you forgot your sql password, you must reset it before attempting this installer again."
                 exit 1
             fi
         done
@@ -195,7 +197,7 @@ install_sql() {
                 fi
             done
         else
-            text_color $YELLOW "No sql repository password detected."
+            text_color $YELLOW"No sql repository password detected."
             for y in {1..2}; do
                 read -p "Enter a new sql repository password (do not leave blank): " password
                 if [ -n "$password" ]; then
@@ -211,7 +213,7 @@ install_sql() {
                         break
                     fi
                 else
-                    text_color $YELLOW "You must enter a sql repository password. Please try again." 
+                    text_color $YELLOW"You must enter a sql repository password. Please try again." 
                 fi
             done
         fi
@@ -305,22 +307,22 @@ clear
 
 cd /root
 
-header_color $BGREEN "Welcome to the OriginTrail Installer. Please sit back while the installer runs. "
+header_color $BGREEN"Welcome to the OriginTrail Installer. Please sit back while the installer runs. "
 
-header_color $BGREEN "Installing OriginTrail node pre-requisites..."
+header_color $BGREEN"Installing OriginTrail node pre-requisites..."
 
 install_prereqs
 
-header_color $BGREEN "Preparing OriginTrail node directory..."
+header_color $BGREEN"Preparing OriginTrail node directory..."
 
 
 if [[ -d "$OTNODE_DIR" ]]; then
     while true; do
         read -p "Previous ot-node directory detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
         case "$choice" in
-        [nN]* ) text_color $GREEN "Keeping previous ot-node directory."; break;;
-        [eE]* ) text_color $RED "Installer stopped by user"; exit;;
-        * ) text_color $GREEN "Reconfiguring ot-node directory."; rm -rf $OTNODE_DIR; install_directory; break;;
+        [nN]* ) text_color $GREEN"Keeping previous ot-node directory."; break;;
+        [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+        * ) text_color $GREEN"Reconfiguring ot-node directory."; rm -rf $OTNODE_DIR; install_directory; break;;
         esac
     done
 else
@@ -329,14 +331,14 @@ fi
 
 OTNODE_DIR=$OTNODE_DIR/current
 
-header_color $BGREEN "Installing Triplestore (Graph Database)..."
+header_color $BGREEN"Installing Triplestore (Graph Database)..."
 
 while true; do
     read -p "Please select the database you would like to use: (Default: Blazegraph) [1]Blazegraph [2]Fuseki [E]xit: " choice
     case "$choice" in
-        [2fF] ) text_color $GREEN "Fuseki selected. Proceeding with installation."; tripleStore=ot-fuseki; break;;
-        [Ee] )  text_color $RED "Installer stopped by user"; exit;;
-        * )     text_color $GREEN "Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph; break;;
+        [2fF] ) text_color $GREEN"Fuseki selected. Proceeding with installation."; tripleStore=ot-fuseki; break;;
+        [Ee] )  text_color $RED"Installer stopped by user"; exit;;
+        * )     text_color $GREEN"Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph; break;;
     esac
 done
 
@@ -345,9 +347,9 @@ if [ $tripleStore = "ot-fuseki" ]; then
         while true; do
             read -p "Previous Fuseki triplestore detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
             case "$choice" in
-            [nN]* ) text_color $GREEN "Keeping previous Fuseki installation."; break;;
-            [eE]* ) text_color $RED "Installer stopped by user"; exit;;
-            * ) text_color $GREEN "Reinstalling Fuseki."; rm -rf fuseki*; install_fuseki; break;;
+            [nN]* ) text_color $GREEN"Keeping previous Fuseki installation."; break;;
+            [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+            * ) text_color $GREEN"Reinstalling Fuseki."; rm -rf fuseki*; install_fuseki; break;;
             esac
         done
     else
@@ -360,9 +362,9 @@ if [ $tripleStore = "ot-blazegraph" ]; then
         while true; do
             read -p "Previous Blazegraph triplestore detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
             case "$choice" in
-            [nN]* ) text_color $GREEN "Keeping old Blazegraph Installation."; break;;
-            [eE]* ) text_color $RED "Installer stopped by user"; exit;;
-            * ) text_color $GREEN "Reinstalling Blazegraph."; rm -rf blazegraph*; install_blazegraph; break;;
+            [nN]* ) text_color $GREEN"Keeping old Blazegraph Installation."; break;;
+            [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+            * ) text_color $GREEN"Reinstalling Blazegraph."; rm -rf blazegraph*; install_blazegraph; break;;
             esac
         done
     else
@@ -370,15 +372,15 @@ if [ $tripleStore = "ot-blazegraph" ]; then
     fi
 fi
 
-header_color $BGREEN "Installing SQL..."
+header_color $BGREEN"Installing SQL..."
 
 install_sql
 
-header_color $BGREEN "Configuring OriginTrail node..."
+header_color $BGREEN"Configuring OriginTrail node..."
 
 install_node
 
-header_color $BGREEN "INSTALLATION COMPLETE !"
+header_color $BGREEN"INSTALLATION COMPLETE !"
 
 text_color $GREEN "
 New aliases added:
@@ -398,4 +400,4 @@ If the logs do not show and the screen hangs, press ctrl+c to exit the installat
 "
 read -p "Press enter to continue..."
 
-journalctl -u otnode --output cat -fn 100
+journalctl -u otnode --output cat -fn 200

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -126,7 +126,7 @@ install_sql() {
             [2]* )  text_color $GREEN"MariaDB selected. Proceeding with installation."
                     sql=mariadb
                     perform_step apt-get install curl software-properties-common dirmngr ca-certificates apt-transport-https -y "Installing mariadb dependencies"
-                    perform_step curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.8 "Setting mariadb version to 10.8"
+                    curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.8
                     perform_step apt-get install mariadb-server -y "Installing mariadb-server"
                     break;;
             [Ee]* ) text_color $RED"Installer stopped by user"; exit;;
@@ -236,7 +236,7 @@ install_sql() {
     fi
     if [ $sql = mariadb ]; then
         perform_step sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mariadb.conf.d/50-server.cnf "Setting max log size"
-        echo -e "disable_log_bin\nwait_timeout = 31536000\ninteractive_timeout = 31536000" >> /etc/mysql/mariadb.conf.d/50-server.cnf "Disabling logs, setting wait timeout and interactive timeout"
+        echo -e "disable_log_bin\nwait_timeout = 31536000\ninteractive_timeout = 31536000" >> /etc/mysql/mariadb.conf.d/50-server.cnf
     fi
     perform_step systemctl restart $sql "Restarting $sql"
 }

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -137,7 +137,7 @@ install_sql() {
                         read -p "Enter a new sql repository password if you wish (do not leave blank): " password
                         if [ -n "$password" ]; then
                             echo -n "Configuring new sql password: "
-                            OUTPUT=$($sql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$password';" 2>&1)
+                            OUTPUT=$($sql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$password';" 2>&1)
                             if [[ $? -ne 0 ]]; then
                                 text_color $RED "FAILED"
                                 echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
@@ -185,7 +185,7 @@ install_sql() {
                 if [ -n "$password" ]; then
                 #if password isn't blank
                     echo -n "Configuring new sql password: "
-                    OUTPUT=$($sql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$password';" 2>&1)
+                    OUTPUT=$($sql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$password';" 2>&1)
                     if [[ $? -ne 0 ]]; then
                         text_color $RED "FAILED"
                         echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"


### PR DESCRIPTION
# Description

- [x] Added MariaDB option as an alternative to MySQL
    - MariaDB replication performance is faster than MySQL
    - MariaDB is fully open source and supports a larger connection pool
    - Going from one SQL to another can cause migration issues and is out of the scope of this installer. The user is warned to select one and stick to it. 
- [x] Added several checks to avoid installer errors or file duplications on reinstalls
    - Checks whether otnode directory is present, offers the choice to remove or keep it
    - Checks whether a triplestore is installed, offers the choice to remove or keep it
    - Checks whether user already has a operationaldb database and remove it

A user who wishes to use the installer again for a reinstall should no longer encounter any errors, mainly operationaldb, fuseki and ot-node directories already exist. Blazegraph.jar and aliases should also no longer replicate several times. The installer is now much more interactive giving the user more options and guidance with default values for each interactive sessions.

Fixes # (issue)

Fixed file or string duplications, errors on reinstallation.
Fixed a syntax error on line 202

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
    - Tested several times choosing different installation options on a fresh Ubuntu 20.04LTS VM and a Ubuntu 22.04 VM.
- [x] Test B
    - Tested on a preexisting node on Ubuntu 20.04 running the latest node version and Blazegraph choosing different installation options

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
