### PR TITLE
Added mariadb support, Arch Linux support, always download latest fuseki, bug fix, checks added for node reinstallation, reduced verbosity

### DIFF
--- a/installer/data/blazegraph.service
+++ b/installer/data/blazegraph.service
@@ -8,8 +8,8 @@ After=network.target
 [Service]
 Type=simple
 User=root
-WorkingDirectory=/root/
-ExecStart=/usr/bin/java -jar /root/blazegraph.jar
+WorkingDirectory=/root/ot-node/
+ExecStart=/usr/bin/java -jar /root/ot-node/blazegraph.jar
 Restart=on-failure
 
 [Install]

--- a/installer/data/fuseki.service
+++ b/installer/data/fuseki.service
@@ -9,8 +9,8 @@ After=network.target
 Environment=JVM_ARGS=-Xmx4G
 Type=simple
 User=root
-WorkingDirectory=/root/fuseki
-ExecStart=/usr/bin/java -jar /root/fuseki/fuseki-server.jar --update --set tdb:unionDefaultGraph=true --loc /root/fuseki/tdb /node0
+WorkingDirectory=/root/ot-node/fuseki
+ExecStart=/usr/bin/java -jar /root/ot-node/fuseki/fuseki-server.jar --update --set tdb:unionDefaultGraph=true --loc /root/ot-node/fuseki/tdb /node0
 Restart=on-failure
 
 [Install]

--- a/installer/data/graphdb.service
+++ b/installer/data/graphdb.service
@@ -8,8 +8,8 @@ After=network.target
 [Service]
 Type=simple
 User=root
-WorkingDirectory=/root/graphdb-free/bin/
-ExecStart=/root/graphdb-free/bin/graphdb
+WorkingDirectory=/root/ot-node/graphdb-free/bin/
+ExecStart=/root/ot-node/graphdb-free/bin/graphdb
 Restart=on-failure
 
 [Install]

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -95,7 +95,12 @@ install_prereqs() {
 }
 
 install_fuseki() {
-    FUSEKI_VER="apache-jena-fuseki-4.6.0"
+    FUSEKI_VER="apache-jena-fuseki-$(git ls-remote --tags https://github.com/apache/jena | grep -o 'refs/tags/jena-[0-9]*\.[0-9]*\.[0-9]*' | sort -r | head -n 1 | grep -o '[^\/-]*$')"
+    FUSEKI_PREV_VER="apache-jena-fuseki-$(git ls-remote --tags https://github.com/apache/jena | grep -o 'refs/tags/jena-[0-9]*\.[0-9]*\.[0-9]*' | sort -r | head -n 3 | tail -n 1 | grep -o '[^\/-]*$')"
+    wget -q --spider https://dlcdn.apache.org/jena/binaries/$FUSEKI_VER.zip
+    if [[ $? -ne 0 ]]; then
+        FUSEKI_VER=$FUSEKI_PREV_VER
+    fi
 
     perform_step wget https://dlcdn.apache.org/jena/binaries/$FUSEKI_VER.zip "Downloading Fuseki"
     perform_step unzip $FUSEKI_VER.zip "Unzipping Fuseki"

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -4,9 +4,8 @@ ARCHIVE_REPOSITORY_URL="github.com/OriginTrail/ot-node/archive"
 BRANCH="v6/release/testnet"
 BRANCH_DIR="/root/ot-node-6-release-testnet"
 OTNODE_DIR="/root/ot-node"
-FUSEKI_VER="apache-jena-fuseki-4.5.0"
+FUSEKI_VER="apache-jena-fuseki-4.6.0"
 NODEJS_VER="16"
-FILE=/root/.bashrc
 
 text_color() {
     GREEN='\033[0;32m'
@@ -39,8 +38,8 @@ perform_step() {
 }
 
 install_aliases() {
-    if [ -f "$FILE" ]; then
-        if grep -Fxq "alias otnode-restart='systemctl restart otnode.service'" $FILE; then
+    if [ -f "/root/.bashrc" ]; then
+        if grep -Fxq "alias otnode-restart='systemctl restart otnode.service'" ~/.bashrc; then
             echo "Aliases found, skipping."
         else
             echo "alias otnode-restart='systemctl restart otnode.service'" >> ~/.bashrc
@@ -48,26 +47,10 @@ install_aliases() {
             echo "alias otnode-start='systemctl start otnode.service'" >> ~/.bashrc
             echo "alias otnode-logs='journalctl -u otnode --output cat -f'" >> ~/.bashrc
             echo "alias otnode-config='nano ~/ot-node/.origintrail_noderc'" >> ~/.bashrc
-            source ~/.bashrc
-            text_color $GREEN OK
         fi
     else
-        echo "$FILE does not exist. Proceeding with OriginTrail node installation."
+        echo "bashrc does not exist. Proceeding with OriginTrail node installation."
     fi
-}
-
-install_directory() {
-    OTNODE_VERSION=$(jq -r '.version' $BRANCH_DIR/package.json)
-
-    mkdir $OTNODE_DIR
-    mkdir $OTNODE_DIR/$OTNODE_VERSION
-
-    mv $BRANCH_DIR/* $OTNODE_DIR/$OTNODE_VERSION/
-    mv $BRANCH_DIR/.* $OTNODE_DIR/$OTNODE_VERSION/
-
-    rm -r $BRANCH_DIR
-
-    ln -sfn $OTNODE_DIR/$OTNODE_VERSION $OTNODE_DIR/current
 }
 
 install_firewall() {
@@ -75,47 +58,97 @@ install_firewall() {
     yes | ufw enable
 }
 
-install_fuseki() {
-    wget https://dlcdn.apache.org/jena/binaries/$FUSEKI_VER.zip
-    unzip $FUSEKI_VER.zip
+install_prereqs() {
+    export DEBIAN_FRONTEND=noninteractive
+    perform_step install_aliases "Updating .bashrc file with OriginTrail node aliases"
+    perform_step rm -rf /var/lib/dpkg/lock-frontend "Removing any frontend locks"
+    perform_step apt update "Updating Ubuntu package repository"
+    perform_step apt upgrade -y "Updating Ubuntu to latest version"
+    perform_step apt install default-jre unzip jq -y "Installing default-jre, unzip, jq"
+    perform_step apt install build-essential -y "Installing build-essential"
+    perform_step wget https://deb.nodesource.com/setup_$NODEJS_VER.x "Downloading Node.js v$NODEJS_VER"
+    chmod +x setup_$NODEJS_VER.x
+    perform_step ./setup_$NODEJS_VER.x "Installing Node.js v$NODEJS_VER"
+    rm -rf setup_$NODEJS_VER.x
+    perform_step apt update "Updating Ubuntu package repository"
+    perform_step apt-get install nodejs -y "Installing node.js"
+    perform_step npm install -g npm "Installing npm"
+    perform_step install_firewall "Configuring firewall"
+    perform_step apt remove unattended-upgrades -y "Remove unattended upgrades"
+}
 
+install_directory() {
+    #Download new version .zip file
+    #Unpack to init folder
+    perform_step wget https://$ARCHIVE_REPOSITORY_URL/$BRANCH.zip "Downloading node files"
+    perform_step unzip *.zip "Unzipping node files"
+    rm *.zip
+    OTNODE_VERSION=$(jq -r '.version' $BRANCH_DIR/package.json)
+    mkdir $OTNODE_DIR
+    mkdir $OTNODE_DIR/$OTNODE_VERSION
+    OUTPUT=$(mv $BRANCH_DIR/* $OTNODE_DIR/$OTNODE_VERSION/ 2>&1)
+    OUTPUT=$(mv $BRANCH_DIR/.* $OTNODE_DIR/$OTNODE_VERSION/ 2>&1)
+    rm -rf $BRANCH_DIR
+    ln -sfn $OTNODE_DIR/$OTNODE_VERSION $OTNODE_DIR/current
+}
+
+install_fuseki() {
+    perform_step wget https://dlcdn.apache.org/jena/binaries/$FUSEKI_VER.zip "Downloading Fuseki"
+    perform_step unzip $FUSEKI_VER.zip "Unzipping Fuseki"
     rm /root/$FUSEKI_VER.zip
     mkdir /root/fuseki
     mkdir /root/fuseki/tdb
     cp /root/$FUSEKI_VER/fuseki-server.jar /root/fuseki/
     cp -r /root/$FUSEKI_VER/webapp/ /root/fuseki/
     rm -r /root/$FUSEKI_VER
-
-    perform_step cp $OTNODE_DIR/installer/data/fuseki.service /lib/systemd/system/
-
+    perform_step cp $OTNODE_DIR/installer/data/fuseki.service /lib/systemd/system/ "Copying Fuseki service file"
     systemctl daemon-reload
-    systemctl enable fuseki
-    systemctl start fuseki
-    systemctl status fuseki
+    perform_step systemctl enable fuseki "Enabling Fuseki"
+    perform_step systemctl start fuseki "Starting Fuseki"
+    perform_step systemctl status fuseki "Fuseki status"
 }
 
 install_blazegraph() {
-    wget https://github.com/blazegraph/database/releases/latest/download/blazegraph.jar
-    cp $OTNODE_DIR/installer/data/blazegraph.service /lib/systemd/system/
-
+    perform_step wget https://github.com/blazegraph/database/releases/latest/download/blazegraph.jar "Downloading Blazegraph"
+    perform_step cp $OTNODE_DIR/installer/data/blazegraph.service /lib/systemd/system/ "Copying Blazegraph service file"
     systemctl daemon-reload
-    systemctl enable blazegraph
-    systemctl start blazegraph
-    systemctl status blazegraph
+    perform_step systemctl enable blazegraph "Enabling Blazegrpah"
+    perform_step systemctl start blazegraph "Starting Blazegraph"
+    perform_step systemctl status blazegraph "Blazegraph status"
 }
 
-install_mysql() {
+install_sql() {
+    text_color $YELLOW"IMPORTANT NOTE: to avoid potential migration issues from one SQL to another, please select the one you are currently using. If this is your first installation, both choices are valid. If you don't know the answer, select [1].
+    "
+    while true; do
+        read -p "Please select the SQL you would like to use: (Default: MySQL) [1]MySQL [2]MariaDB [E]xit " choice
+        case "$choice" in
+            [2]* )  text_color $GREEN"MariaDB selected. Proceeding with installation."
+                    sql=mariadb
+                    perform_step apt-get install curl software-properties-common dirmngr ca-certificates apt-transport-https -y "Installing mariadb dependencies"
+                    curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.8
+                    perform_step apt-get install mariadb-server -y "Installing mariadb-server"
+                    break;;
+            [Ee]* ) text_color $RED"Installer stopped by user"; exit;;
+            * )     text_color $GREEN"MySQL selected. Proceeding with installation."
+                    sql=mysql
+                    mysql_native_password=" WITH mysql_native_password"
+                    perform_step apt-get install tcllib mysql-server -y "Installing mysql-server"
+                    break;;
+        esac
+    done
+
     if [ -d "/var/lib/mysql/operationaldb/" ]; then
-    #check if operationaldb already exists
+    #checks if operationaldb already exists, overwrite it if it does and ask user to input a new password (if old one was empty)
         text_color $YELLOW "Old sql database detected. Please enter your sql password to overwrite it."
         for x in {1..5}; do
             read -p "Enter your sql repository password (leave blank if none): " password
             echo -n "Deleting old sql database: "
-            OUTPUT=$(MYSQL_PWD=$password mysql -u root -e "DROP DATABASE IF EXISTS operationaldb;" 2>&1)     
+            OUTPUT=$(MYSQL_PWD=$password $sql -u root -e "DROP DATABASE IF EXISTS operationaldb;" 2>&1)     
             if [[ $? -ne 0 ]]; then
                 text_color $RED "FAILED"
                 echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
-                text_color $YELLOW "Wrong password entered. Try again ($x/5)"
+                text_color $YELLOW"Wrong password entered. Try again ($x/5)"
             else
                 text_color $GREEN "OK"
                 if [ -z "$password" ]; then
@@ -123,7 +156,7 @@ install_mysql() {
                         read -p "Enter a new sql repository password if you wish (do not leave blank): " password
                         if [ -n "$password" ]; then
                             echo -n "Configuring new sql password: "
-                            OUTPUT=$(mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$password';" 2>&1)
+                            OUTPUT=$($sql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED$mysql_native_password BY '$password';" 2>&1)
                             if [[ $? -ne 0 ]]; then
                                 text_color $RED "FAILED"
                                 echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
@@ -133,26 +166,25 @@ install_mysql() {
                                 break
                             fi
                         else
-                            text_color $YELLOW "You must enter a sql repository password. Please try again." 
+                            text_color $YELLOW"You must enter a sql repository password. Please try again." 
                         fi
                     done
                 fi
                 break
             fi
             if [ $x == 5 ]; then
-                text_color $RED "FAILED. If you forgot your sql password, you must reset it before attempting this installer again."
+                text_color $RED"FAILED. If you forgot your sql password, you must reset it before attempting this installer again."
                 exit 1
             fi
         done
     else
-        OUTPUT=$(mysql -u root -e "status;" 2>&1)
-        #check if sql is password protected
+    #if operationaldb doesn't exist, check if sql is password protected, if not, prompt user to create one
+        OUTPUT=$($sql -u root -e "status;" 2>&1)
         if [[ $? -ne 0 ]]; then
             for y in {1..5}; do
                 read -p "Enter your sql repository password: " password
                 echo -n "Password check: "
-                OUTPUT=$(MYSQL_PWD=$password mysql -u root -e "status;" 2>&1)
-                #check whether entered password matches current sql password
+                OUTPUT=$(MYSQL_PWD=$password $sql -u root -e "status;" 2>&1)
                 if [[ $? -ne 0 ]]; then
                     text_color $YELLOW "ERROR - The sql password provided does not match your current sql password. Please try again ($y/5)"
                 else
@@ -165,13 +197,13 @@ install_mysql() {
                 fi
             done
         else
-            text_color $YELLOW "No sql repository password detected."
+            text_color $YELLOW"No sql repository password detected."
             for y in {1..2}; do
                 read -p "Enter a new sql repository password (do not leave blank): " password
                 if [ -n "$password" ]; then
                 #if password isn't blank
                     echo -n "Configuring new sql password: "
-                    OUTPUT=$(mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$password';" 2>&1)
+                    OUTPUT=$($sql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED$mysql_native_password BY '$password';" 2>&1)
                     if [[ $? -ne 0 ]]; then
                         text_color $RED "FAILED"
                         echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
@@ -181,7 +213,7 @@ install_mysql() {
                         break
                     fi
                 else
-                    text_color $YELLOW "You must enter a sql repository password. Please try again." 
+                    text_color $YELLOW"You must enter a sql repository password. Please try again." 
                 fi
             done
         fi
@@ -189,7 +221,7 @@ install_mysql() {
 
     echo "REPOSITORY_PASSWORD=$password" > $OTNODE_DIR/.env
     echo -n "Creating new sql database: "
-    OUTPUT=$(MYSQL_PWD=$password mysql -u root -e "CREATE DATABASE operationaldb /*\!40100 DEFAULT CHARACTER SET utf8 */;" 2>&1)
+    OUTPUT=$(MYSQL_PWD=$password $sql -u root -e "CREATE DATABASE operationaldb /*\!40100 DEFAULT CHARACTER SET utf8 */;" 2>&1)
     if [[ $? -ne 0 ]]; then
         text_color $RED "FAILED"
         echo -e "${N1}Step failed. Output of error is:${N1}${N1}$OUTPUT"
@@ -197,133 +229,175 @@ install_mysql() {
     else
         text_color $GREEN "OK"
     fi
-    perform_step sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting max log size"
-    echo "disable_log_bin" >> /etc/mysql/mysql.conf.d/mysqld.cnf
-    perform_step sed -i '/disable_log_bin/a\wait_timeout=31536000' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting wait timeout"
-    perform_step sed -i '/disable_log_bin/a\interactive_timeout=31536000' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting interactive timeout"
-
-    systemctl restart mysql
+    
+    if [ $sql = mysql ]; then
+        perform_step sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mysql.conf.d/mysqld.cnf "Setting max log size"
+        echo -e "disable_log_bin\nwait_timeout = 31536000\ninteractive_timeout = 31536000" >> /etc/mysql/mysql.conf.d/mysqld.cnf
+    fi
+    if [ $sql = mariadb ]; then
+        perform_step sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mariadb.conf.d/50-server.cnf "Setting max log size"
+        echo -e "disable_log_bin\nwait_timeout = 31536000\ninteractive_timeout = 31536000" >> /etc/mysql/mariadb.conf.d/50-server.cnf
+    fi
+    perform_step systemctl restart $sql "Restarting $sql"
 }
 
 install_node() {
+
+    CONFIG_DIR=$OTNODE_DIR/..
+
+    #blockchains=("otp" "polygon")
+    #for ((i = 0; i < ${#blockchains[@]}; ++i));
+    #do
+    #   read -p "Do you want to connect your node to blockchain: ${blockchains[$i]} ? [Y]Yes [N]No [E]Exit: " choice
+    #	case "$choice" in
+    #       [Yy]* )
+
+    #            read -p "Enter your substrate operational wallet address: " SUBSTRATE_OPERATIONAL_WALLET
+    #            echo "Substrate operational wallet address: $SUBSTRATE_OPERATIONAL_WALLET"
+
+    #            read -p "Enter your substrate operational wallet private key: " SUBSTRATE_OPERATIONAL_PRIVATE_KEY
+    #            echo "Substrate operational wallet private key: $SUBSTRATE_OPERATIONAL_PRIVATE_KEY"
+
+                read -p "Enter your EVM operational wallet address: " EVM_OPERATIONAL_WALLET
+                text_color $GREEN "EVM operational wallet address: $EVM_OPERATIONAL_WALLET"
+
+                read -p "Enter your EVM operational wallet private key: " EVM_OPERATIONAL_PRIVATE_KEY
+                text_color $GREEN "EVM operational wallet private key: $EVM_OPERATIONAL_PRIVATE_KEY"
+
+    #            read -p "Enter your substrate management wallet address: " SUBSTRATE_MANAGEMENT_WALLET
+    #            echo "Substrate management wallet address: $SUBSTRATE_MANAGEMENT_WALLET"
+
+    #            read -p "Enter your substrate management wallet private key: " SUBSTRATE_MANAGEMENT_WALLET_PRIVATE_KEY
+    #            echo "Substrate management wallet private key: $SUBSTRATE_MANAGEMENT_WALLET_PRIVATE_KEY"
+
+                read -p "Enter your EVM management wallet address: " EVM_MANAGEMENT_WALLET
+                text_color $GREEN "EVM management wallet address: $EVM_MANAGEMENT_WALLET"
+
+    #            read -p "Enter your EVM management wallet private key: " EVM_MANAGEMENT_PRIVATE_KEY
+    #            echo "EVM management wallet private key: $EVM_MANAGEMENT_PRIVATE_KEY"
+                # ;;
+    #      [Nn]* ) ;;
+    #     [Ee]* ) echo "Installer stopped by user"; exit;;
+        #    * ) ((--i));echo "Please make a valid choice and try again.";;
+        #esac
+    #done
+    
     # Change directory to ot-node/current
     cd $OTNODE_DIR
 
-    npm ci --omit=dev --ignore-scripts "Executing npm ci --omit=dev --ignore-scripts"
+    perform_step npm ci --omit=dev --ignore-scripts "Executing npm install"
 
     echo "NODE_ENV=testnet" >> $OTNODE_DIR/.env
 
-    touch $CONFIG_DIR/.origintrail_noderc
+    perform_step touch $CONFIG_DIR/.origintrail_noderc "Configuring node config file"
     jq --null-input --arg tripleStore "$tripleStore" '{"logLevel": "trace", "auth": {"ipWhitelist": ["::1", "127.0.0.1"]}, "modules": {"tripleStore":{"defaultImplementation": $tripleStore}}}' > $CONFIG_DIR/.origintrail_noderc
 
     jq --arg blockchain "otp" --arg evmOperationalWallet "$EVM_OPERATIONAL_WALLET" --arg evmOperationalWalletPrivateKey "$EVM_OPERATIONAL_PRIVATE_KEY" --arg evmManagementWallet "$EVM_MANAGEMENT_WALLET" '.modules.blockchain.implementation[$blockchain].config |= { "evmOperationalWalletPublicKey": $evmOperationalWallet, "evmOperationalWalletPrivateKey": $evmOperationalWalletPrivateKey, "evmManagementWalletPublicKey": $evmManagementWallet} + .' $CONFIG_DIR/.origintrail_noderc > $CONFIG_DIR/origintrail_noderc_tmp
     mv $CONFIG_DIR/origintrail_noderc_tmp $CONFIG_DIR/.origintrail_noderc
 
-    cp $OTNODE_DIR/installer/data/otnode.service /lib/systemd/system/
+    perform_step cp $OTNODE_DIR/installer/data/otnode.service /lib/systemd/system/ "Copying otnode service file"
     
     systemctl daemon-reload
-    systemctl enable otnode
-    systemctl start otnode
-    systemctl status otnode
+    perform_step systemctl enable otnode "Enabling otnode"
+    perform_step systemctl start otnode "Starting otnode"
+    perform_step systemctl status otnode "otnode status"
 }
 
 clear
 
 cd /root
 
-header_color $BGREEN "Welcome to the OriginTrail Installer. Please sit back while the installer runs. "
+header_color $BGREEN"Welcome to the OriginTrail Installer. Please sit back while the installer runs. "
 
-header_color $BGREEN "Installing OriginTrail node pre-requisites..."
+header_color $BGREEN"Installing OriginTrail node pre-requisites..."
 
-perform_step install_aliases "Updating .bashrc file with OriginTrail node aliases"
-perform_step rm /var/lib/dpkg/lock-frontend "Removing any frontend locks"
-perform_step apt update "Updating Ubuntu package repository"
-perform_step export DEBIAN_FRONTEND=noninteractive "Updating Ubuntu to latest version 1/2"
-perform_step apt upgrade -y "Updating Ubuntu to latest version 2/2"
-perform_step apt install default-jre unzip jq -y "Installing default-jre, unzip, jq"
-perform_step apt install build-essential -y "Installing build-essential"
-perform_step wget https://$ARCHIVE_REPOSITORY_URL/$BRANCH.zip "Downloading ot-node"
-perform_step unzip *.zip "Unzipping ot-node"
-perform_step rm *.zip "Removing zip file"
-#Download new version .zip file
-#Unpack to init folder
-perform_step wget https://deb.nodesource.com/setup_$NODEJS_VER.x "Downloading Node.js v$NODEJS_VER"
-chmod +x setup_$NODEJS_VER.x
-perform_step ./setup_$NODEJS_VER.x "Installing Node.js v$NODEJS_VER"
-rm -rf setup_$NODEJS_VER.x
-perform_step apt update "Updating the Ubuntu repo"
-perform_step apt-get install nodejs -y "Installing node.js"
-perform_step npm install -g npm "Installing npm"
-perform_step apt-get install tcllib mysql-server -y "Installing tcllib and mysql-server"
-perform_step apt remove unattended-upgrades -y "Remove unattended upgrades"
-perform_step install_directory "Assembling ot-node directory"
-perform_step install_firewall "Configuring firewall"
+install_prereqs
+
+header_color $BGREEN"Preparing OriginTrail node directory..."
+
+
+if [[ -d "$OTNODE_DIR" ]]; then
+    while true; do
+        read -p "Previous ot-node directory detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
+        case "$choice" in
+        [nN]* ) text_color $GREEN"Keeping previous ot-node directory."; break;;
+        [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+        * ) text_color $GREEN"Reconfiguring ot-node directory."; rm -rf $OTNODE_DIR; install_directory; break;;
+        esac
+    done
+else
+    install_directory
+fi
 
 OTNODE_DIR=$OTNODE_DIR/current
 
-header_color $BGREEN "Installing Triplestore (Graph Database)..."
+header_color $BGREEN"Installing Triplestore (Graph Database)..."
 
 while true; do
-    read -p "Please select the database you would like to use: [1]Fuseki [2]Blazegraph [E]xit: " choice
+    read -p "Please select the database you would like to use: (Default: Blazegraph) [1]Blazegraph [2]Fuseki [E]xit: " choice
     case "$choice" in
-        [1gG]* ) echo -e "Fuseki selected. Proceeding with installation."; tripleStore=ot-fuseki; perform_step install_fuseki "Installing Fuseki"; break;;
-        [2bB]* ) echo -e "Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph; perform_step install_blazegraph "Installing Blazegraph"; break;;
-        [Ee]* ) echo "Installer stopped by user"; exit;;
-        * ) echo "Please make a valid choice and try again.";;
+        [2fF] ) text_color $GREEN"Fuseki selected. Proceeding with installation."; tripleStore=ot-fuseki; break;;
+        [Ee] )  text_color $RED"Installer stopped by user"; exit;;
+        * )     text_color $GREEN"Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph; break;;
     esac
 done
 
-header_color $BGREEN "Installing MySQL..."
+if [ $tripleStore = "ot-fuseki" ]; then
+    if [ -d "/root/fuseki" ]; then
+        while true; do
+            read -p "Previous Fuseki triplestore detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
+            case "$choice" in
+            [nN]* ) text_color $GREEN"Keeping previous Fuseki installation."; break;;
+            [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+            * ) text_color $GREEN"Reinstalling Fuseki."; rm -rf fuseki*; install_fuseki; break;;
+            esac
+        done
+    else
+        install_fuseki
+    fi
+fi
 
-install_mysql
+if [ $tripleStore = "ot-blazegraph" ]; then
+    if [ -f "blazegraph.jar" ]; then
+        while true; do
+            read -p "Previous Blazegraph triplestore detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
+            case "$choice" in
+            [nN]* ) text_color $GREEN"Keeping old Blazegraph Installation."; break;;
+            [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+            * ) text_color $GREEN"Reinstalling Blazegraph."; rm -rf blazegraph*; install_blazegraph; break;;
+            esac
+        done
+    else
+        install_blazegraph
+    fi
+fi
 
-header_color $BGREEN "Configuring OriginTrail node..."
+header_color $BGREEN"Installing SQL..."
 
-CONFIG_DIR=$OTNODE_DIR/..
+install_sql
 
-#blockchains=("otp" "polygon")
-#for ((i = 0; i < ${#blockchains[@]}; ++i));
-#do
-#   read -p "Do you want to connect your node to blockchain: ${blockchains[$i]} ? [Y]Yes [N]No [E]Exit: " choice
-#	case "$choice" in
-#       [Yy]* )
+header_color $BGREEN"Configuring OriginTrail node..."
 
-#            read -p "Enter your substrate operational wallet address: " SUBSTRATE_OPERATIONAL_WALLET
-#            echo "Substrate operational wallet address: $SUBSTRATE_OPERATIONAL_WALLET"
+install_node
 
-#            read -p "Enter your substrate operational wallet private key: " SUBSTRATE_OPERATIONAL_PRIVATE_KEY
-#            echo "Substrate operational wallet private key: $SUBSTRATE_OPERATIONAL_PRIVATE_KEY"
+header_color $BGREEN"INSTALLATION COMPLETE !"
 
-            read -p "Enter your EVM operational wallet address: " EVM_OPERATIONAL_WALLET
-            text_color $GREEN "EVM operational wallet address: $EVM_OPERATIONAL_WALLET"
+text_color $GREEN "
+New aliases added:
+otnode-restart
+otnode-stop
+otnode-start
+otnode-logs
+otnode-config
 
-            read -p "Enter your EVM operational wallet private key: " EVM_OPERATIONAL_PRIVATE_KEY
-            text_color $GREEN "EVM operational wallet private key: $EVM_OPERATIONAL_PRIVATE_KEY"
+To start using aliases, run:
+source ~/.bashrc
+"
+text_color $YELLOW"Logs will be displayed. Press ctrl+c to exit the logs. The node WILL stay running after you return to the command prompt.
 
-#            read -p "Enter your substrate management wallet address: " SUBSTRATE_MANAGEMENT_WALLET
-#            echo "Substrate management wallet address: $SUBSTRATE_MANAGEMENT_WALLET"
+If the logs do not show and the screen hangs, press ctrl+c to exit the installation and reboot your server.
 
-#            read -p "Enter your substrate management wallet private key: " SUBSTRATE_MANAGEMENT_WALLET_PRIVATE_KEY
-#            echo "Substrate management wallet private key: $SUBSTRATE_MANAGEMENT_WALLET_PRIVATE_KEY"
-
-            read -p "Enter your EVM management wallet address: " EVM_MANAGEMENT_WALLET
-            text_color $GREEN "EVM management wallet address: $EVM_MANAGEMENT_WALLET"
-
-#            read -p "Enter your EVM management wallet private key: " EVM_MANAGEMENT_PRIVATE_KEY
-#            echo "EVM management wallet private key: $EVM_MANAGEMENT_PRIVATE_KEY"
-            # ;;
-#      [Nn]* ) ;;
-#     [Ee]* ) echo "Installer stopped by user"; exit;;
-    #    * ) ((--i));echo "Please make a valid choice and try again.";;
-    #esac
-#done
-
-perform_step install_node "Configuring ot-node"
-
-text_color $GREEN "Logs will be displayed. Press ctrl+c to exit the logs. The node WILL stay running after you return to the command prompt."
-echo ""
-text_color $GREEN "If the logs do not show and the screen hangs, press ctrl+c to exit the installation and reboot your server."
-echo ""
+"
 read -p "Press enter to continue..."
 
-journalctl -u otnode --output cat -fn 100
+journalctl -u otnode --output cat -fn 200

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -291,7 +291,7 @@ if [[ -d "$OTNODE_DIR" ]]; then
     case "$choice" in
         [nN]* ) text_color $GREEN"Keeping previous ot-node directory.";;
         [eE]* ) text_color $RED"Installer stopped by user"; exit;;
-        * ) text_color $GREEN"Reconfiguring ot-node directory."; perform_step rm -rf $OTNODE_DIR "Deleting $OTNODE_DIR"; install_directory;;
+        * ) text_color $GREEN"Reconfiguring ot-node directory."; systemctl is-active --quiet otnode && systemctl stop otnode; perform_step rm -rf $OTNODE_DIR "Deleting $OTNODE_DIR"; install_directory;;
     esac
 else
     install_directory

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -104,7 +104,7 @@ install_fuseki() {
     perform_step cp $OTNODE_DIR/installer/data/fuseki.service /lib/systemd/system/ "Copying Fuseki service file"
     systemctl daemon-reload
     perform_step systemctl enable fuseki "Enabling Fuseki"
-    perform_step systemctl start fuseki "Starting Fuseki"
+    perform_step systemctl restart fuseki "Starting Fuseki"
     perform_step systemctl status fuseki "Fuseki status"
 }
 
@@ -113,7 +113,7 @@ install_blazegraph() {
     perform_step cp $OTNODE_DIR/installer/data/blazegraph.service /lib/systemd/system/ "Copying Blazegraph service file"
     systemctl daemon-reload
     perform_step systemctl enable blazegraph "Enabling Blazegrpah"
-    perform_step systemctl start blazegraph "Starting Blazegraph"
+    perform_step systemctl restart blazegraph "Starting Blazegraph"
     perform_step systemctl status blazegraph "Blazegraph status"
 }
 
@@ -299,7 +299,7 @@ install_node() {
     
     systemctl daemon-reload
     perform_step systemctl enable otnode "Enabling otnode"
-    perform_step systemctl start otnode "Starting otnode"
+    perform_step systemctl restart otnode "Starting otnode"
     perform_step systemctl status otnode "otnode status"
 }
 


### PR DESCRIPTION
# Description

- [x] Added MariaDB option as an alternative to MySQL
    - MariaDB replication performance is faster than MySQL
    - MariaDB is fully open source and supports a larger connection pool
    - For more comparisons, consult this [link](https://www.guru99.com/mariadb-vs-mysql.html)

- [x] Added many options for sql installation
    - User can now choose between MySQL and MariaDB
      - Updating from MySQL to MariaDB is possible but not the other way around. However, since there is still a risk of migration issues, it is advised to stick to the same sql and migration is beyond the scope of this installer.
    - User can now validate their current sql password (if any)
    - User can check whether a operationaldb database exists and offers the option to remove or keep it
    - User can now update their current sql password
    - Added hidden password typing for security reasons and retyping password for confirmation

- [x] Always install latest version of fuseki
    - Fuseki download would fail when new fuseki version is available. Added a workaround to always install the latest version available.

- [x] Added several checks to avoid installer errors or file duplications on reinstalls
    - Checks whether otnode directory is present, offers the choice to remove or keep it
    - Checks whether a triplestore is installed, offers the choice to remove or keep it

- [x] Added Arch Linux installation support. 
    - *The Arch Linux support still requires a file called archlinux to be added on the ~/ot-node/current/installer/data folder. I am missing rights to add this file. The content of that file would be: https://github.com/Valcyclovir/testnet/blob/main/archlinux*

- [x] Added several interactive sessions to let user decide to overwrite or keep existing node directory / triplestore / database

- [x] Added instruction to source .bashrc and a list of added aliases at the end of installation
    - *Current way to source .bashrc within the script will only source it within the subshell and will not work outside of it. source .bashrc will require manual intervention after the installation process*

- [x] Added publicIP to node config file for nodes behind a NAT

- [x] Several installation text styling and code optimizations

- [x] Reduced verbosity
  - the installation now works in 5 sections:
    - install prerequisites
    - install node directory
    - install triplestore
    - install sql
    - install node
  - Many other verbosity reduction across the script. 

Codes are rearranged to their respective sections and put into functions to facilitate future changes.

A user who wishes to use the installer again for a reinstall should no longer encounter any errors - mainly operationaldb already exists error, or fuseki and ot-node directories already exist errors. Blazegraph.jar and aliases should also no longer replicate several times. The installer is now much more interactive giving the user more options and guidance with default values for each installation step. The user can now select specific parts to reinstall and skip the rest, such as reinstalling the ot-node directory only, changing from blazegraph to fuseki or any other future triplestore, upgrading from mysql to mariadb.

Fixes # (issue)

- Fixed Blazegraph.jar duplications on each reinstall
- Fixed installation error when operationaldb already exists from previous installation
- Fixed fuseki and node directory already exist from previous installation
- Fixed aliases duplications on reinstall
- Fixed fuseki download fails when fuseki version updates

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
    - Tested several times choosing different installation options on a fresh Ubuntu 20.04 VM and a Ubuntu 22.04 VM.
- [x] Test B
    - Tested on a preexisting node on Ubuntu 20.04
- [x] Test C
    - Tested on Arch Linux based distribution EndeavourOS
- [x] Test D
   - Several community members running different setups have engaged with the script and managed to get through the installation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
