### PR TITLE
InstallerV2: Added mariadb support, Arch Linux support, always download latest stable fuseki, bug fix, node/triplestore/sql checks, reduced verbosity

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -311,6 +311,32 @@ case "$choice" in
     * )     text_color $GREEN"Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph;;
 esac
 
+if [[ $tripleStore = "ot-fuseki" ]]; then
+    if [[ -d "/root/fuseki" ]]; then
+        read -p "Previously installed Fuseki triplestore detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
+        case "$choice" in
+            [nN]* ) text_color $GREEN"Keeping previous Fuseki installation.";;
+            [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+            * )     text_color $GREEN"Reinstalling Fuseki."; perform_step rm -rf fuseki* "Removing previous Fuseki installation"; install_fuseki;;
+        esac
+    else
+        install_fuseki
+    fi
+fi
+
+if [[ $tripleStore = "ot-blazegraph" ]]; then
+    if [[ -f "blazegraph.jar" ]]; then
+        read -p "Previously installed Blazegraph triplestore detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
+        case "$choice" in
+            [nN]* ) text_color $GREEN"Keeping old Blazegraph Installation.";;
+            [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+            * )     text_color $GREEN"Reinstalling Blazegraph."; perform_step rm -rf blazegraph* "Removing previous Blazegraph installation"; install_blazegraph;;
+        esac
+    else
+        install_blazegraph
+    fi
+fi
+
 header_color $BGREEN "Installing MySQL..."
 
 install_mysql

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -6,7 +6,6 @@ BRANCH_DIR="/root/ot-node-6-release-testnet"
 OTNODE_DIR="/root/ot-node"
 FUSEKI_VER="apache-jena-fuseki-4.5.0"
 NODEJS_VER="16"
-FILE=/root/.bashrc
 
 text_color() {
     GREEN='\033[0;32m'
@@ -39,8 +38,8 @@ perform_step() {
 }
 
 install_aliases() {
-    if [ -f "$FILE" ]; then
-        if grep -Fxq "alias otnode-restart='systemctl restart otnode.service'" $FILE; then
+    if [[ -f "/root/.bashrc" ]]; then
+        if grep -Fxq "alias otnode-restart='systemctl restart otnode.service'" ~/.bashrc; then
             echo "Aliases found, skipping."
         else
             echo "alias otnode-restart='systemctl restart otnode.service'" >> ~/.bashrc
@@ -48,11 +47,9 @@ install_aliases() {
             echo "alias otnode-start='systemctl start otnode.service'" >> ~/.bashrc
             echo "alias otnode-logs='journalctl -u otnode --output cat -f'" >> ~/.bashrc
             echo "alias otnode-config='nano ~/ot-node/.origintrail_noderc'" >> ~/.bashrc
-            source ~/.bashrc
-            text_color $GREEN OK
         fi
     else
-        echo "$FILE does not exist. Proceeding with OriginTrail node installation."
+        echo "bashrc does not exist. Proceeding with OriginTrail node installation."
     fi
 }
 

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -2,7 +2,6 @@
 
 OTNODE_DIR="/root/ot-node"
 FUSEKI_VER="apache-jena-fuseki-4.5.0"
-NODEJS_VER="16"
 
 text_color() {
     GREEN='\033[0;32m'
@@ -70,6 +69,28 @@ install_directory() {
 install_firewall() {
     ufw allow 22/tcp && ufw allow 8900 && ufw allow 9000
     yes | ufw enable
+}
+
+install_prereqs() {
+    export DEBIAN_FRONTEND=noninteractive
+    NODEJS_VER="16"
+
+    perform_step install_aliases "Updating .bashrc file with OriginTrail node aliases"
+    perform_step rm -rf /var/lib/dpkg/lock-frontend "Removing any frontend locks"
+    perform_step apt update "Updating Ubuntu package repository"
+    perform_step apt upgrade -y "Updating Ubuntu to latest version"
+    perform_step apt install unzip jq -y "Installing unzip, jq"
+    perform_step apt install default-jre -y "Installing default-jre"
+    perform_step apt install build-essential -y "Installing build-essential"
+    perform_step wget https://deb.nodesource.com/setup_$NODEJS_VER.x "Downloading Node.js v$NODEJS_VER"
+    chmod +x setup_$NODEJS_VER.x
+    perform_step ./setup_$NODEJS_VER.x "Installing Node.js v$NODEJS_VER"
+    rm -rf setup_$NODEJS_VER.x
+    perform_step apt update "Updating Ubuntu package repository"
+    perform_step apt-get install nodejs -y "Installing node.js"
+    perform_step npm install -g npm "Installing npm"
+    perform_step install_firewall "Configuring firewall"
+    perform_step apt remove unattended-upgrades -y "Remove unattended upgrades"
 }
 
 install_fuseki() {
@@ -232,25 +253,6 @@ cd /root
 header_color $BGREEN "Welcome to the OriginTrail Installer. Please sit back while the installer runs. "
 
 header_color $BGREEN "Installing OriginTrail node pre-requisites..."
-
-perform_step install_aliases "Updating .bashrc file with OriginTrail node aliases"
-perform_step rm /var/lib/dpkg/lock-frontend "Removing any frontend locks"
-perform_step apt update "Updating Ubuntu package repository"
-perform_step export DEBIAN_FRONTEND=noninteractive "Updating Ubuntu to latest version 1/2"
-perform_step apt upgrade -y "Updating Ubuntu to latest version 2/2"
-perform_step apt install default-jre unzip jq -y "Installing default-jre, unzip, jq"
-perform_step apt install build-essential -y "Installing build-essential"
-perform_step wget https://deb.nodesource.com/setup_$NODEJS_VER.x "Downloading Node.js v$NODEJS_VER"
-chmod +x setup_$NODEJS_VER.x
-perform_step ./setup_$NODEJS_VER.x "Installing Node.js v$NODEJS_VER"
-rm -rf setup_$NODEJS_VER.x
-perform_step apt update "Updating the Ubuntu repo"
-perform_step apt-get install nodejs -y "Installing node.js"
-perform_step npm install -g npm "Installing npm"
-perform_step apt-get install tcllib mysql-server -y "Installing tcllib and mysql-server"
-perform_step apt remove unattended-upgrades -y "Remove unattended upgrades"
-perform_step install_directory "Assembling ot-node directory"
-perform_step install_firewall "Configuring firewall"
 
 OTNODE_DIR=$OTNODE_DIR/current
 

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -281,23 +281,35 @@ clear
 
 cd /root
 
-header_color $BGREEN "Welcome to the OriginTrail Installer. Please sit back while the installer runs. "
+header_color $BGREEN"Welcome to the OriginTrail Installer. Please sit back while the installer runs. "
 
-header_color $BGREEN "Installing OriginTrail node pre-requisites..."
+header_color $BGREEN"Installing OriginTrail node pre-requisites..."
+
+install_prereqs
+
+header_color $BGREEN"Preparing OriginTrail node directory..."
+
+if [[ -d "$OTNODE_DIR" ]]; then
+    read -p "Previous ot-node directory detected. Would you like to overwrite it? (Default: Yes) [Y]es [N]o [E]xit " choice
+    case "$choice" in
+        [nN]* ) text_color $GREEN"Keeping previous ot-node directory.";;
+        [eE]* ) text_color $RED"Installer stopped by user"; exit;;
+        * ) text_color $GREEN"Reconfiguring ot-node directory."; systemctl is-active --quiet otnode && systemctl stop otnode; perform_step rm -rf $OTNODE_DIR "Deleting $OTNODE_DIR"; install_directory;;
+    esac
+else
+    install_directory
+fi
 
 OTNODE_DIR=$OTNODE_DIR/current
 
-header_color $BGREEN "Installing Triplestore (Graph Database)..."
+header_color $BGREEN"Installing Triplestore (Graph Database)..."
 
-while true; do
-    read -p "Please select the database you would like to use: [1]Fuseki [2]Blazegraph [E]xit: " choice
-    case "$choice" in
-        [1gG]* ) echo -e "Fuseki selected. Proceeding with installation."; tripleStore=ot-fuseki; perform_step install_fuseki "Installing Fuseki"; break;;
-        [2bB]* ) echo -e "Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph; perform_step install_blazegraph "Installing Blazegraph"; break;;
-        [Ee]* ) echo "Installer stopped by user"; exit;;
-        * ) echo "Please make a valid choice and try again.";;
-    esac
-done
+read -p "Please select the database you would like to use: (Default: Blazegraph) [1]Blazegraph [2]Fuseki [E]xit: " choice
+case "$choice" in
+    [2fF] ) text_color $GREEN"Fuseki selected. Proceeding with installation."; tripleStore=ot-fuseki;;
+    [Ee] )  text_color $RED"Installer stopped by user"; exit;;
+    * )     text_color $GREEN"Blazegraph selected. Proceeding with installation."; tripleStore=ot-blazegraph;;
+esac
 
 header_color $BGREEN "Installing MySQL..."
 

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -337,20 +337,32 @@ if [[ $tripleStore = "ot-blazegraph" ]]; then
     fi
 fi
 
-header_color $BGREEN "Installing MySQL..."
+header_color $BGREEN"Installing SQL..."
 
-install_mysql
+install_sql
 
-header_color $BGREEN "Configuring OriginTrail node..."
+header_color $BGREEN"Configuring OriginTrail node..."
 
+install_node
 
+header_color $BGREEN"INSTALLATION COMPLETE !"
 
-perform_step install_node "Configuring ot-node"
+text_color $GREEN "
+New aliases added:
+otnode-restart
+otnode-stop
+otnode-start
+otnode-logs
+otnode-config
 
-text_color $GREEN "Logs will be displayed. Press ctrl+c to exit the logs. The node WILL stay running after you return to the command prompt."
-echo ""
-text_color $GREEN "If the logs do not show and the screen hangs, press ctrl+c to exit the installation and reboot your server."
-echo ""
+To start using aliases, run:
+source ~/.bashrc
+"
+text_color $YELLOW"Logs will be displayed. Press ctrl+c to exit the logs. The node WILL stay running after you return to the command prompt.
+
+If the logs do not show and the screen hangs, press ctrl+c to exit the installation and reboot your server.
+
+"
 read -p "Press enter to continue..."
 
-journalctl -u otnode --output cat -fn 100
+journalctl -u otnode --output cat -fn 200

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-ARCHIVE_REPOSITORY_URL="github.com/OriginTrail/ot-node/archive"
-BRANCH="v6/release/testnet"
-BRANCH_DIR="/root/ot-node-6-release-testnet"
 OTNODE_DIR="/root/ot-node"
 FUSEKI_VER="apache-jena-fuseki-4.5.0"
 NODEJS_VER="16"
@@ -54,17 +51,20 @@ install_aliases() {
 }
 
 install_directory() {
+    ARCHIVE_REPOSITORY_URL="github.com/OriginTrail/ot-node/archive"
+    BRANCH="v6/release/testnet"
+    BRANCH_DIR="/root/ot-node-6-release-testnet"
+
+    perform_step wget https://$ARCHIVE_REPOSITORY_URL/$BRANCH.zip "Downloading node files"
+    perform_step unzip *.zip "Unzipping node files"
+    perform_step rm *.zip "Removing zip file"
     OTNODE_VERSION=$(jq -r '.version' $BRANCH_DIR/package.json)
-
-    mkdir $OTNODE_DIR
-    mkdir $OTNODE_DIR/$OTNODE_VERSION
-
-    mv $BRANCH_DIR/* $OTNODE_DIR/$OTNODE_VERSION/
-    mv $BRANCH_DIR/.* $OTNODE_DIR/$OTNODE_VERSION/
-
-    rm -r $BRANCH_DIR
-
-    ln -sfn $OTNODE_DIR/$OTNODE_VERSION $OTNODE_DIR/current
+    perform_step mkdir $OTNODE_DIR "Creating new ot-node directory"
+    perform_step mkdir $OTNODE_DIR/$OTNODE_VERSION "Creating new ot-node version directory"
+    perform_step mv $BRANCH_DIR/* $OTNODE_DIR/$OTNODE_VERSION/ "Moving downloaded node files to ot-node version directory"
+    OUTPUT=$(mv $BRANCH_DIR/.* $OTNODE_DIR/$OTNODE_VERSION/ 2>&1)
+    perform_step rm -rf $BRANCH_DIR "Removing old directories"
+    perform_step ln -sfn $OTNODE_DIR/$OTNODE_VERSION $OTNODE_DIR/current "Creating symlink from $OTNODE_DIR/$OTNODE_VERSION to $OTNODE_DIR/current"
 }
 
 install_firewall() {
@@ -240,11 +240,6 @@ perform_step export DEBIAN_FRONTEND=noninteractive "Updating Ubuntu to latest ve
 perform_step apt upgrade -y "Updating Ubuntu to latest version 2/2"
 perform_step apt install default-jre unzip jq -y "Installing default-jre, unzip, jq"
 perform_step apt install build-essential -y "Installing build-essential"
-perform_step wget https://$ARCHIVE_REPOSITORY_URL/$BRANCH.zip "Downloading ot-node"
-perform_step unzip *.zip "Unzipping ot-node"
-perform_step rm *.zip "Removing zip file"
-#Download new version .zip file
-#Unpack to init folder
 perform_step wget https://deb.nodesource.com/setup_$NODEJS_VER.x "Downloading Node.js v$NODEJS_VER"
 chmod +x setup_$NODEJS_VER.x
 perform_step ./setup_$NODEJS_VER.x "Installing Node.js v$NODEJS_VER"

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -271,6 +271,12 @@ install_node() {
     perform_step systemctl status otnode "otnode service status"
 }
 
+#For Arch Linux installation
+if [[ ! -z $(grep "arch" "/etc/os-release") ]]; then
+    source <(curl -s https://raw.githubusercontent.com/OriginTrail/ot-node/v6/develop/installer/data/archlinux)
+fi
+
+#### INSTALLATION START ####
 clear
 
 cd /root

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -116,14 +116,13 @@ install_fuseki() {
 }
 
 install_blazegraph() {
-    wget https://github.com/blazegraph/database/releases/latest/download/blazegraph.jar
+    perform_step wget https://github.com/blazegraph/database/releases/latest/download/blazegraph.jar "Downloading Blazegraph"
+    perform_step cp $OTNODE_DIR/installer/data/blazegraph.service /lib/systemd/system/ "Copying Blazegraph service file"
     mv blazegraph.jar $OTNODE_DIR/../blazegraph.jar
-    cp $OTNODE_DIR/installer/data/blazegraph.service /lib/systemd/system/
-
     systemctl daemon-reload
-    systemctl enable blazegraph
-    systemctl start blazegraph
-    systemctl status blazegraph
+    perform_step systemctl enable blazegraph "Enabling Blazegrpah"
+    perform_step systemctl start blazegraph "Starting Blazegraph"
+    perform_step systemctl status blazegraph "Blazegraph status"
 }
 
 install_mysql() {


### PR DESCRIPTION
# Description

- [x] Added MariaDB option as an alternative to MySQL
    - MariaDB replication performance is faster than MySQL
    - MariaDB is fully open source and supports a larger connection pool
    - For more comparisons, consult this [link](https://www.guru99.com/mariadb-vs-mysql.html)

- [x] Added many options for sql installation
    - User can now choose between MySQL and MariaDB
      - Updating from MySQL to MariaDB is possible but not the other way around. However, since there is still a risk of migration issues, it is advised to stick to the same sql and migration is beyond the scope of this installer.
    - User can now validate their current sql password (if any)
    - User can check whether a operationaldb database exists and offers the option to remove or keep it
    - User can now update their current sql password
    - Added hidden password typing for security reasons and retyping password for confirmation

- [x] Always install latest version of fuseki
    - Before, Fuseki download would fail when new fuseki version becomes available. Added a workaround to always install the latest stable version available.

- [x] Added several checks to avoid installer errors or file duplications on reinstalls
    - Checks whether otnode directory is present, offers the choice to remove or keep it
    - Checks whether a triplestore is installed, offers the choice to remove or keep it

- [x] Added Arch Linux installation support. 
    - Added a small footprint on the installerv2 to include Arch Linux support.

- [x] Added several interactive sessions to let user decide to overwrite or keep existing node directory / triplestore / database

- [x] Added instruction to source .bashrc and a list of added aliases at the end of installation
    - *Current way to source .bashrc within the script will only source it within the subshell and will not work outside of it. source .bashrc will require manual intervention after the installation process*

- [x] Several installation text styling and code optimizations

- [x] Reduced verbosity
  - the installation now works in 5 sections:
    - install prerequisites
    - install node directory
    - install triplestore
    - install sql
    - install node
  - Many other verbosity reduction across the script. 

Codes are rearranged to their respective sections and put into functions to facilitate future changes.

A user who wishes to use the installer again for a reinstall should no longer encounter any errors - mainly operationaldb already exists error, or fuseki and ot-node directories already exist errors. Blazegraph.jar and aliases should also no longer replicate several times. The installer is now much more interactive giving the user more options and guidance with default values for each installation step. The user can now select specific parts to reinstall and skip the rest, such as reinstalling the ot-node directory only, changing from blazegraph to fuseki or any other future triplestore, upgrading from mysql to mariadb.

Fixes # (issue)

- Fixed missing arg for sharesTokenName and sharesTokenSymbol
- Fixed Blazegraph.jar duplications on each reinstall
- Fixed installation error when operationaldb already exists from previous installation
- Fixed fuseki and node directory already exist from previous installation
- Fixed aliases duplications on reinstall
- Fixed fuseki download fails when fuseki version updates

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

This installer has been tested over the past months by many community members.

- [x] Test A
    - Tested several times choosing different installation options on a fresh Ubuntu 20.04 VM and a Ubuntu 22.04 VM.
- [x] Test B
    - Tested on a preexisting node on Ubuntu 20.04
- [x] Test C
    - Tested on Arch Linux based distribution EndeavourOS
- [x] Test D
   - Several community members running different setups have engaged with the script and managed to get through the installation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
