### PR TITLE
Devnet 6.0.4 Prerelease - setting versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "origintrail_node",
-    "version": "6.0.4+hotfix.5",
+    "version": "6.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "origintrail_node",
-            "version": "6.0.4+hotfix.5",
+            "version": "6.0.4",
             "license": "ISC",
             "dependencies": {
                 "@comunica/query-sparql": "^2.4.3",
@@ -25,7 +25,7 @@
                 "axios": "^0.27.2",
                 "cors": "^2.8.5",
                 "deep-extend": "^0.6.0",
-                "dkg-evm-module": "^4.0.3",
+                "dkg-evm-module": "^4.0.4",
                 "dotenv": "^16.0.1",
                 "ethers": "^5.7.2",
                 "express": "^4.18.1",
@@ -7622,9 +7622,9 @@
             }
         },
         "node_modules/dkg-evm-module": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/dkg-evm-module/-/dkg-evm-module-4.0.3.tgz",
-            "integrity": "sha512-PNavYwi0vdloteb6/CDaeVFqBpYaCRDquObg1LnU8ZzS7/E2nRBue5ugdWT8LZx/mnE5zk8KO2oG7C0SCQkymA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/dkg-evm-module/-/dkg-evm-module-4.0.4.tgz",
+            "integrity": "sha512-f/lDWwI69yWW/lm9JKyUCVbzPMYRj3IIIFgTUuUsMu1Kjf6g3BYyZimddVoapxbWkir0nS7PVSu3hH3wU3HDuA==",
             "dependencies": {
                 "@openzeppelin/contracts": "^4.7.3",
                 "@polkadot/api": "^10.1.4",
@@ -25732,9 +25732,9 @@
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
         },
         "dkg-evm-module": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/dkg-evm-module/-/dkg-evm-module-4.0.3.tgz",
-            "integrity": "sha512-PNavYwi0vdloteb6/CDaeVFqBpYaCRDquObg1LnU8ZzS7/E2nRBue5ugdWT8LZx/mnE5zk8KO2oG7C0SCQkymA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/dkg-evm-module/-/dkg-evm-module-4.0.4.tgz",
+            "integrity": "sha512-f/lDWwI69yWW/lm9JKyUCVbzPMYRj3IIIFgTUuUsMu1Kjf6g3BYyZimddVoapxbWkir0nS7PVSu3hH3wU3HDuA==",
             "requires": {
                 "@openzeppelin/contracts": "^4.7.3",
                 "@polkadot/api": "^10.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "origintrail_node",
-    "version": "6.0.4+hotfix.5",
+    "version": "6.0.4",
     "description": "OTNode V6",
     "main": "index.js",
     "type": "module",
@@ -80,7 +80,7 @@
         "axios": "^0.27.2",
         "cors": "^2.8.5",
         "deep-extend": "^0.6.0",
-        "dkg-evm-module": "^4.0.3",
+        "dkg-evm-module": "^4.0.4",
         "dotenv": "^16.0.1",
         "ethers": "^5.7.2",
         "express": "^4.18.1",


### PR DESCRIPTION
# Description

- Set version to back 6.0.4 and bump dkg-evm-module version.