### PR TITLE
[BUGFIX] Installer script update - npm command improved with proper installation version

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -87,7 +87,7 @@ install_prereqs() {
     rm -rf setup_$NODEJS_VER.x
     perform_step apt update "Updating Ubuntu package repository"
     perform_step apt-get install nodejs -y "Installing node.js"
-    perform_step npm install -g npm "Installing npm"
+    perform_step npm install -g npm@^8 "Installing npm"
     perform_step install_firewall "Configuring firewall"
     perform_step apt remove unattended-upgrades -y "Remove unattended upgrades"
 }
@@ -263,9 +263,9 @@ install_node() {
     perform_step touch $CONFIG_DIR/.origintrail_noderc "Configuring node config file"
     perform_step $(jq --null-input --arg tripleStore "$tripleStore" '{"logLevel": "trace", "auth": {"ipWhitelist": ["::1", "127.0.0.1"]}}' > $CONFIG_DIR/.origintrail_noderc) "Adding loglevel and auth values to node config file"
 
-    perform_step $(jq --arg tripleStore "$tripleStore" --arg tripleStoreUrl "$tripleStoreUrl" '.modules.tripleStore.implementation[$tripleStore] |= 
+    perform_step $(jq --arg tripleStore "$tripleStore" --arg tripleStoreUrl "$tripleStoreUrl" '.modules.tripleStore.implementation[$tripleStore] |=
         {
-            "enabled": "true", 
+            "enabled": "true",
             "config": {
                 "repositories": {
                     "privateCurrent": {
@@ -293,24 +293,24 @@ install_node() {
                         "password": ""
                     }
                 }
-            } 
+            }
         } + .' $CONFIG_DIR/.origintrail_noderc > $CONFIG_DIR/origintrail_noderc_tmp) "Adding node wallets to node config file 1/2"
 
     perform_step mv $CONFIG_DIR/origintrail_noderc_tmp $CONFIG_DIR/.origintrail_noderc "Adding node wallets to node config file 2/2"
-    
-    perform_step $(jq --arg blockchain "otp" --arg evmOperationalWallet "$EVM_OPERATIONAL_WALLET" --arg evmOperationalWalletPrivateKey "$EVM_OPERATIONAL_PRIVATE_KEY" --arg evmManagementWallet "$EVM_MANAGEMENT_WALLET" --arg evmManagementWallet "$SHARES_TOKEN_NAME" --arg evmManagementWallet "$SHARES_TOKEN_SYMBOL" --arg sharesTokenName "$SHARES_TOKEN_NAME" --arg sharesTokenSymbol "$SHARES_TOKEN_SYMBOL" '.modules.blockchain.implementation[$blockchain].config |= 
-        { 
-            "evmOperationalWalletPublicKey": $evmOperationalWallet, 
-            "evmOperationalWalletPrivateKey": $evmOperationalWalletPrivateKey, 
-            "evmManagementWalletPublicKey": $evmManagementWallet, 
-            "sharesTokenName": $sharesTokenName, 
+
+    perform_step $(jq --arg blockchain "otp" --arg evmOperationalWallet "$EVM_OPERATIONAL_WALLET" --arg evmOperationalWalletPrivateKey "$EVM_OPERATIONAL_PRIVATE_KEY" --arg evmManagementWallet "$EVM_MANAGEMENT_WALLET" --arg evmManagementWallet "$SHARES_TOKEN_NAME" --arg evmManagementWallet "$SHARES_TOKEN_SYMBOL" --arg sharesTokenName "$SHARES_TOKEN_NAME" --arg sharesTokenSymbol "$SHARES_TOKEN_SYMBOL" '.modules.blockchain.implementation[$blockchain].config |=
+        {
+            "evmOperationalWalletPublicKey": $evmOperationalWallet,
+            "evmOperationalWalletPrivateKey": $evmOperationalWalletPrivateKey,
+            "evmManagementWalletPublicKey": $evmManagementWallet,
+            "sharesTokenName": $sharesTokenName,
             "sharesTokenSymbol": $sharesTokenSymbol
         } + .' $CONFIG_DIR/.origintrail_noderc > $CONFIG_DIR/origintrail_noderc_tmp) "Adding node wallets to node config file 1/2"
-    
+
     perform_step mv $CONFIG_DIR/origintrail_noderc_tmp $CONFIG_DIR/.origintrail_noderc "Adding node wallets to node config file 2/2"
 
     perform_step cp $OTNODE_DIR/installer/data/otnode.service /lib/systemd/system/ "Copying otnode service file"
-    
+
     systemctl daemon-reload
     perform_step systemctl enable otnode "Enabling otnode"
     perform_step systemctl start otnode "Starting otnode"


### PR DESCRIPTION
# Description

This PR fixes an issue with the installer script that currently installs the wrong NPM version

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- The issue was detected by the automated test executed on the installer on a daily basis
- The update was tested on the Ubuntu 20.04 LTS instance and confirmed to install proper NPM version required for the OriginTrail DKG node. 


- [ ] Manually on an Ubuntu 20.04 distribution

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
