### PR TITLE
Invalid SAs migration rework

### DIFF
--- a/ot-node.js
+++ b/ot-node.js
@@ -87,16 +87,16 @@ class OTNode {
             this.config,
         );
         await MigrationExecutor.executePendingStorageMigration(this.logger, this.config);
-        MigrationExecutor.executeServiceAgreementsDataInspector(
-            this.container,
-            this.logger,
-            this.config,
-        );
-        await MigrationExecutor.executeServiceAgreementsInvalidDataMigration(
-            this.container,
-            this.logger,
-            this.config,
-        );
+        // MigrationExecutor.executeServiceAgreementsDataInspector(
+        //     this.container,
+        //     this.logger,
+        //     this.config,
+        // );
+        // await MigrationExecutor.executeServiceAgreementsInvalidDataMigration(
+        //     this.container,
+        //     this.logger,
+        //     this.config,
+        // );
         await this.createProfiles();
 
         await this.initializeCommandExecutor();

--- a/ot-node.js
+++ b/ot-node.js
@@ -87,7 +87,12 @@ class OTNode {
             this.config,
         );
         await MigrationExecutor.executePendingStorageMigration(this.logger, this.config);
-        await MigrationExecutor.executeServiceAgreementsOpDatabaseMigration(
+        MigrationExecutor.executeServiceAgreementsDataInspector(
+            this.container,
+            this.logger,
+            this.config,
+        );
+        await MigrationExecutor.executeServiceAgreementsInvalidDataMigration(
             this.container,
             this.logger,
             this.config,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "origintrail_node",
-    "version": "6.0.20+hotfix.1",
+    "version": "6.0.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "origintrail_node",
-            "version": "6.0.20+hotfix.1",
+            "version": "6.0.20",
             "license": "ISC",
             "dependencies": {
                 "@comunica/query-sparql": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "origintrail_node",
-    "version": "6.0.20+hotfix.1",
+    "version": "6.0.20",
     "description": "OTNode V6",
     "main": "index.js",
     "type": "module",

--- a/src/migration/base-migration.js
+++ b/src/migration/base-migration.js
@@ -22,10 +22,10 @@ class BaseMigration {
         this.fileService = new FileService({ config: this.config, logger: this.logger });
     }
 
-    async migrationAlreadyExecuted() {
+    async migrationAlreadyExecuted(migrationName = null) {
         const migrationFilePath = path.join(
             this.fileService.getMigrationFolderPath(),
-            this.migrationName,
+            migrationName ?? this.migrationName,
         );
         if (await this.fileService.pathExists(migrationFilePath)) {
             return true;
@@ -52,9 +52,9 @@ class BaseMigration {
         );
     }
 
-    async getMigrationInfo() {
+    async getMigrationInfo(migrationName = null) {
         const migrationFolderPath = this.fileService.getMigrationFolderPath();
-        const migrationInfoFileName = `${this.migrationName}_info`;
+        const migrationInfoFileName = `${migrationName ?? this.migrationName}_info`;
         const migrationInfoPath = path.join(migrationFolderPath, migrationInfoFileName);
         let migrationInfo = null;
         if (await this.fileService.pathExists(migrationInfoPath)) {

--- a/src/migration/migration-executor.js
+++ b/src/migration/migration-executor.js
@@ -243,8 +243,9 @@ class MigrationExecutor {
 
         const blockchainModuleManager = container.resolve('blockchainModuleManager');
         const repositoryModuleManager = container.resolve('repositoryModuleManager');
-        const serviceAgreementService = container.resolve('serviceAgreementService');
+        const tripleStoreService = container.resolve('tripleStoreService');
         const ualService = container.resolve('ualService');
+        const serviceAgreementService = container.resolve('serviceAgreementService');
 
         const migration = new ServiceAgreementsDataInspector(
             'serviceAgreementsDataInspector',
@@ -252,8 +253,9 @@ class MigrationExecutor {
             config,
             blockchainModuleManager,
             repositoryModuleManager,
-            serviceAgreementService,
+            tripleStoreService,
             ualService,
+            serviceAgreementService,
         );
         if (!(await migration.migrationAlreadyExecuted())) {
             await migration.migrate();

--- a/src/migration/migration-executor.js
+++ b/src/migration/migration-executor.js
@@ -9,7 +9,8 @@ import TripleStoreMetadataMigration from './triple-store-metadata-migration.js';
 import RemoveOldEpochCommandsMigration from './remove-old-epoch-commands-migration.js';
 import PendingStorageMigration from './pending-storage-migration.js';
 import MarkOldBlockchainEventsAsProcessedMigration from './mark-old-blockchain-events-as-processed-migration.js';
-import ServiceAgreementsOpDatabaseMigration from './service-agreements-op-database-migration.js';
+import ServiceAgreementsDataInspector from './service-agreements-data-inspector.js';
+import ServiceAgreementsInvalidDataMigration from './service-agreements-invalid-data-migration.js';
 
 class MigrationExecutor {
     static async executePullShardingTableMigration(container, logger, config) {
@@ -233,8 +234,7 @@ class MigrationExecutor {
         }
     }
 
-    static async executeServiceAgreementsOpDatabaseMigration(container, logger, config) {
-        // todo should we also exclude testnet?
+    static async executeServiceAgreementsDataInspector(container, logger, config) {
         if (
             process.env.NODE_ENV === NODE_ENVIRONMENTS.DEVELOPMENT ||
             process.env.NODE_ENV === NODE_ENVIRONMENTS.TEST
@@ -246,8 +246,8 @@ class MigrationExecutor {
         const serviceAgreementService = container.resolve('serviceAgreementService');
         const ualService = container.resolve('ualService');
 
-        const migration = new ServiceAgreementsOpDatabaseMigration(
-            'serviceAgreementsOpDatabaseMigration',
+        const migration = new ServiceAgreementsDataInspector(
+            'serviceAgreementsDataInspector',
             logger,
             config,
             blockchainModuleManager,
@@ -256,6 +256,33 @@ class MigrationExecutor {
             ualService,
         );
         if (!(await migration.migrationAlreadyExecuted())) {
+            await migration.migrate();
+            logger.info('Node will now restart!');
+            MigrationExecutor.exitNode(1);
+        }
+    }
+
+    static async executeServiceAgreementsInvalidDataMigration(container, logger, config) {
+        if (
+            process.env.NODE_ENV === NODE_ENVIRONMENTS.DEVELOPMENT ||
+            process.env.NODE_ENV === NODE_ENVIRONMENTS.TEST
+        )
+            return;
+
+        const repositoryModuleManager = container.resolve('repositoryModuleManager');
+        const tripleStoreService = container.resolve('tripleStoreService');
+
+        const migration = new ServiceAgreementsInvalidDataMigration(
+            'serviceAgreementsInvalidDataMigration',
+            logger,
+            config,
+            repositoryModuleManager,
+            tripleStoreService,
+        );
+        if (
+            (await migration.migrationAlreadyExecuted('serviceAgreementsDataInspector')) &&
+            !(await migration.migrationAlreadyExecuted())
+        ) {
             await migration.migrate();
         }
     }

--- a/src/migration/private-assets-metadata-migration.js
+++ b/src/migration/private-assets-metadata-migration.js
@@ -113,7 +113,7 @@ class PrivateAssetsMetadataMigration extends BaseMigration {
             tokenId,
         );
 
-        await this.tripleStoreService.insertAssetMetadata(
+        await this.tripleStoreService.insertAssetAssertionMetadata(
             TRIPLE_STORE_REPOSITORIES.PRIVATE_CURRENT,
             blockchain,
             assetStorageContractAddress,
@@ -131,7 +131,7 @@ class PrivateAssetsMetadataMigration extends BaseMigration {
 
         if (privateAssertionId == null || !assertionIds.includes(privateAssertionId)) return;
 
-        await this.tripleStoreService.insertAssetMetadata(
+        await this.tripleStoreService.insertAssetAssertionMetadata(
             TRIPLE_STORE_REPOSITORIES.PRIVATE_CURRENT,
             blockchain,
             assetStorageContractAddress,

--- a/src/migration/service-agreements-data-inspector.js
+++ b/src/migration/service-agreements-data-inspector.js
@@ -135,9 +135,11 @@ class ServiceAgreementsDataInspector extends BaseMigration {
                 contract: serviceAgreement.assetStorageContractAddress,
                 tokenId: serviceAgreement.tokenId,
                 agreementId: updatedServiceAgreement.agreementId ?? serviceAgreement.agreementId,
-                keyword: updatedServiceAgreement.keyword ?? serviceAgreement.keyword,
-                invalidAssertionId: serviceAgreement.assertionId,
-                assertionId: updatedServiceAgreement.assertionId ?? serviceAgreement.assertionId,
+                currentKeyword: serviceAgreement.keyword,
+                correctKeyword: updatedServiceAgreement.keyword ?? serviceAgreement.keyword,
+                currentAssertionId: serviceAgreement.assertionId,
+                correctAssertionId:
+                    updatedServiceAgreement.assertionId ?? serviceAgreement.assertionId,
                 stateIndex: updatedServiceAgreement.stateIndex ?? serviceAgreement.stateIndex,
             });
         }

--- a/src/migration/service-agreements-invalid-data-migration.js
+++ b/src/migration/service-agreements-invalid-data-migration.js
@@ -1,0 +1,101 @@
+/* eslint-disable no-await-in-loop */
+import BaseMigration from './base-migration.js';
+import { TRIPLE_STORE_REPOSITORIES } from '../constants/constants.js';
+
+class ServiceAgreementsInvalidDataMigration extends BaseMigration {
+    constructor(migrationName, logger, config, repositoryModuleManager, tripleStoreService) {
+        super(migrationName, logger, config);
+        this.repositoryModuleManager = repositoryModuleManager;
+        this.tripleStoreService = tripleStoreService;
+    }
+
+    async executeMigration() {
+        let migrationInfo = await this.getMigrationInfo();
+        if (!migrationInfo?.lastFixedTokenId) {
+            migrationInfo = {
+                lastFixedTokenId: 0,
+            };
+        }
+
+        const serviceAgreementsDataInspectorInfo = await this.getMigrationInfo(
+            'serviceAgreementsDataInspector',
+        );
+        const serviceAgreementsToUpdate =
+            serviceAgreementsDataInspectorInfo.fixedServiceAgreements.sort(
+                (a, b) => a.tokenId - b.tokenId,
+            );
+
+        for (const serviceAgreement of serviceAgreementsToUpdate) {
+            if (serviceAgreement.tokenId < migrationInfo.lastFixedTokenId) {
+                continue;
+            }
+
+            this.logger.trace(
+                `Fixing Service Agreement in the Operational DB for the Knowledge Asset with the ID: ${serviceAgreement.tokenId}, ` +
+                    `Service Agreement ID: ${serviceAgreement.agreementId}, Keyword: ${serviceAgreement.keyword}, Assertion ID: ${serviceAgreement.assertionId}, State Index: ${serviceAgreement.stateIndex}.`,
+            );
+
+            await this.repositoryModuleManager.updateServiceAgreementForTokenId(
+                serviceAgreement.tokenId,
+                serviceAgreement.agreementId,
+                serviceAgreement.keyword,
+                serviceAgreement.assertionId,
+                serviceAgreement.stateIndex,
+            );
+
+            if (serviceAgreement.invalidAssertionId === serviceAgreement.assertionId) {
+                continue;
+            }
+
+            if (
+                await this.tripleStoreService.assetAssertionLinkExists(
+                    TRIPLE_STORE_REPOSITORIES.PUBLIC_CURRENT,
+                    serviceAgreement.blockchain,
+                    serviceAgreement.contract,
+                    serviceAgreement.tokenId,
+                    serviceAgreement.invalidAssertionId,
+                )
+            ) {
+                this.logger.trace(
+                    `Fixing Service Agreement in the Triple Store (repository: ${TRIPLE_STORE_REPOSITORIES.PRIVATE_CURRENT}) for the Knowledge Asset with the ID: ` +
+                        `${serviceAgreement.tokenId}, Service Agreement ID: ${serviceAgreement.agreementId}, ` +
+                        `Keyword: ${serviceAgreement.keyword}, Assertion ID: ${serviceAgreement.assertionId}, State Index: ${serviceAgreement.stateIndex}.`,
+                );
+
+                await this.tripleStoreService.updateAssetAssertionLink(
+                    TRIPLE_STORE_REPOSITORIES.PUBLIC_CURRENT,
+                    serviceAgreement.blockchain,
+                    serviceAgreement.contract,
+                    serviceAgreement.tokenId,
+                    serviceAgreement.invalidAssertionId,
+                    serviceAgreement.assertionId,
+                );
+            } else if (
+                await this.tripleStoreService.assetAssertionLinkExists(
+                    TRIPLE_STORE_REPOSITORIES.PRIVATE_CURRENT,
+                    serviceAgreement.blockchain,
+                    serviceAgreement.contract,
+                    serviceAgreement.tokenId,
+                    serviceAgreement.invalidAssertionId,
+                )
+            ) {
+                this.logger.trace(
+                    `Fixing Service Agreement in the Triple Store (repository: ${TRIPLE_STORE_REPOSITORIES.PRIVATE_CURRENT}) for the Knowledge Asset with the ID: ` +
+                        `${serviceAgreement.tokenId}, Service Agreement ID: ${serviceAgreement.agreementId}, ` +
+                        `Keyword: ${serviceAgreement.keyword}, Assertion ID: ${serviceAgreement.assertionId}, State Index: ${serviceAgreement.stateIndex}.`,
+                );
+
+                await this.tripleStoreService.updateAssetAssertionLink(
+                    TRIPLE_STORE_REPOSITORIES.PRIVATE_CURRENT,
+                    serviceAgreement.blockchain,
+                    serviceAgreement.contract,
+                    serviceAgreement.tokenId,
+                    serviceAgreement.invalidAssertionId,
+                    serviceAgreement.assertionId,
+                );
+            }
+        }
+    }
+}
+
+export default ServiceAgreementsInvalidDataMigration;

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -117,6 +117,12 @@ class OtTripleStore {
                     }
                 }`;
             await this.queryVoid(repository, deleteQuery);
+
+            const linkedAssets = await this.countAssetsWithAssertionId(repository, assertionId);
+
+            if (linkedAssets === 0) {
+                await this.deleteAssertion(repository, assertionId);
+            }
         }
     }
 
@@ -140,6 +146,12 @@ class OtTripleStore {
                     }
                 }`;
             await this.queryVoid(repository, updateQuery);
+
+            const linkedAssets = await this.countAssetsWithAssertionId(repository, oldAssertionId);
+
+            if (linkedAssets === 0) {
+                await this.deleteAssertion(repository, oldAssertionId);
+            }
         }
     }
 

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -117,12 +117,6 @@ class OtTripleStore {
                     }
                 }`;
             await this.queryVoid(repository, deleteQuery);
-
-            const linkedAssets = await this.countAssetsWithAssertionId(repository, assertionId);
-
-            if (linkedAssets === 0) {
-                await this.deleteAssertion(repository, assertionId);
-            }
         }
     }
 
@@ -146,12 +140,6 @@ class OtTripleStore {
                     }
                 }`;
             await this.queryVoid(repository, updateQuery);
-
-            const linkedAssets = await this.countAssetsWithAssertionId(repository, oldAssertionId);
-
-            if (linkedAssets === 0) {
-                await this.deleteAssertion(repository, oldAssertionId);
-            }
         }
     }
 
@@ -176,6 +164,29 @@ class OtTripleStore {
             }`;
 
         return this.ask(repository, query);
+    }
+
+    async updateAssetNonAssertionMetadata(repository, ual, assetNquads) {
+        const updateQuery = `
+            PREFIX schema: <${SCHEMA_CONTEXT}>
+            DELETE {
+                GRAPH <assets:graph> {
+                    <${ual}> ?p ?o .
+                    FILTER(?p != schema:assertion)
+                }
+            }
+            INSERT {
+                GRAPH <assets:graph> { 
+                    ${assetNquads} 
+                }
+            }
+            WHERE {
+                GRAPH <assets:graph> {
+                    <${ual}> ?p ?o .
+                    FILTER(?p != schema:assertion)
+                }
+            }`;
+        await this.queryVoid(repository, updateQuery);
     }
 
     async deleteAssetMetadata(repository, ual) {
@@ -210,7 +221,7 @@ class OtTripleStore {
         return this.select(repository, query);
     }
 
-    async insertAssetMetadata(repository, assetNquads) {
+    async insertAssetAssertionMetadata(repository, assetNquads) {
         const query = `
             PREFIX schema: <${SCHEMA_CONTEXT}>
             INSERT DATA {

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -90,6 +90,59 @@ class OtTripleStore {
         return this.ask(repository, query);
     }
 
+    async insertAssetAssertionLink(repository, ual, assertionId) {
+        const assetExists = await this.assetExists(repository, ual);
+
+        if (assetExists) {
+            const insertQuery = `
+                PREFIX schema: <${SCHEMA_CONTEXT}>
+                INSERT DATA {
+                    GRAPH <assets:graph> {
+                        <${ual}> schema:assertion <assertion:${assertionId}> .
+                    }
+                }`;
+            await this.queryVoid(repository, insertQuery);
+        }
+    }
+
+    async deleteAssetAssertionLink(repository, ual, assertionId) {
+        const linkExists = await this.assetAssertionLinkExists(repository, ual, assertionId);
+
+        if (linkExists) {
+            const deleteQuery = `
+                PREFIX schema: <${SCHEMA_CONTEXT}>
+                DELETE DATA {
+                    GRAPH <assets:graph> {
+                        <${ual}> schema:assertion <assertion:${assertionId}> .
+                    }
+                }`;
+            await this.queryVoid(repository, deleteQuery);
+        }
+    }
+
+    async updateAssetAssertionLink(repository, ual, oldAssertionId, newAssertionId) {
+        const linkExists = await this.assetAssertionLinkExists(repository, ual, oldAssertionId);
+
+        if (linkExists) {
+            const updateQuery = `
+                PREFIX schema: <${SCHEMA_CONTEXT}>
+                DELETE {
+                    GRAPH <assets:graph> {
+                        <${ual}> schema:assertion <assertion:${oldAssertionId}> .
+                    }
+                } INSERT {
+                    GRAPH <assets:graph> {
+                        <${ual}> schema:assertion <assertion:${newAssertionId}> .
+                    }
+                } WHERE {
+                    GRAPH <assets:graph> {
+                        <${ual}> schema:assertion <assertion:${oldAssertionId}> .
+                    }
+                }`;
+            await this.queryVoid(repository, updateQuery);
+        }
+    }
+
     async getAssetAssertionLinks(repository, ual) {
         const query = `PREFIX schema: <${SCHEMA_CONTEXT}>
                         SELECT ?assertion  WHERE {
@@ -99,6 +152,18 @@ class OtTripleStore {
                         }`;
 
         return this.select(repository, query);
+    }
+
+    async assetAssertionLinkExists(repository, ual, assertionId) {
+        const query = `
+            PREFIX schema: <${SCHEMA_CONTEXT}>
+            ASK {
+                GRAPH <assets:graph> {
+                    <${ual}> schema:assertion <assertion:${assertionId}> .
+                }
+            }`;
+
+        return this.ask(repository, query);
     }
 
     async deleteAssetMetadata(repository, ual) {

--- a/src/modules/triple-store/triple-store-module-manager.js
+++ b/src/modules/triple-store/triple-store-module-manager.js
@@ -1,10 +1,20 @@
 import BaseModuleManager from '../base-module-manager.js';
 
 class TripleStoreModuleManager extends BaseModuleManager {
-    async insertAssetMetadata(implementationName, repository, assetNquads) {
+    async insertAssetAssertionMetadata(implementationName, repository, assetNquads) {
         if (this.getImplementation(implementationName)) {
-            return this.getImplementation(implementationName).module.insertAssetMetadata(
+            return this.getImplementation(implementationName).module.insertAssetAssertionMetadata(
                 repository,
+                assetNquads,
+            );
+        }
+    }
+
+    async updateAssetNonAssertionMetadata(implementationName, repository, ual, assetNquads) {
+        if (this.getImplementation(implementationName)) {
+            return this.getImplementation(implementationName).module.updateAssetMetadata(
+                repository,
+                ual,
                 assetNquads,
             );
         }
@@ -25,11 +35,58 @@ class TripleStoreModuleManager extends BaseModuleManager {
         }
     }
 
+    async insertAssetAssertionLink(implementationName, repository, ual, assertionId) {
+        if (this.getImplementation(implementationName)) {
+            return this.getImplementation(implementationName).module.insertAssetAssertionLink(
+                repository,
+                ual,
+                assertionId,
+            );
+        }
+    }
+
+    async deleteAssetAssertionLink(implementationName, repository, ual, assertionId) {
+        if (this.getImplementation(implementationName)) {
+            return this.getImplementation(implementationName).module.deleteAssetAssertionLink(
+                repository,
+                ual,
+                assertionId,
+            );
+        }
+    }
+
+    async updateAssetAssertionLink(
+        implementationName,
+        repository,
+        ual,
+        oldAssertionId,
+        newAssertionId,
+    ) {
+        if (this.getImplementation(implementationName)) {
+            return this.getImplementation(implementationName).module.updateAssetAssertionLink(
+                repository,
+                ual,
+                oldAssertionId,
+                newAssertionId,
+            );
+        }
+    }
+
     async getAssetAssertionLinks(implementationName, repository, ual) {
         if (this.getImplementation(implementationName)) {
             return this.getImplementation(implementationName).module.getAssetAssertionLinks(
                 repository,
                 ual,
+            );
+        }
+    }
+
+    async assetAssertionLinkExists(implementationName, repository, ual, assertionId) {
+        if (this.getImplementation(implementationName)) {
+            return this.getImplementation(implementationName).module.assetAssertionLinkExists(
+                repository,
+                ual,
+                assertionId,
             );
         }
     }

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -188,6 +188,51 @@ class TripleStoreService {
         );
     }
 
+    async insertAssetAssertionLink(repository, blockchain, contract, tokenId, assertionId) {
+        const ual = this.ualService.deriveUAL(blockchain, contract, tokenId);
+
+        return this.tripleStoreModuleManager.insertAssetAssertionLink(
+            this.repositoryImplementations[repository],
+            repository,
+            ual,
+            assertionId,
+        );
+    }
+
+    async deleteAssetAssertionLink(repository, blockchain, contract, tokenId, assertionId) {
+        const ual = this.ualService.deriveUAL(blockchain, contract, tokenId);
+
+        return this.tripleStoreModuleManager.deleteAssetAssertionLink(
+            this.repositoryImplementations[repository],
+            repository,
+            ual,
+            assertionId,
+        );
+    }
+
+    async updateAssetAssertionLink(
+        repository,
+        blockchain,
+        contract,
+        tokenId,
+        oldAssertionId,
+        newAssertionId,
+    ) {
+        const ual = this.ualService.deriveUAL(blockchain, contract, tokenId);
+        this.logger.info(
+            `Updating Assertion for the Knowledge Asset with the UAL: ${ual} in the triple store ${repository} repository. ` +
+                `Old Assertion ID: ${oldAssertionId}. New Assertion ID: ${newAssertionId}.`,
+        );
+
+        return this.tripleStoreModuleManager.updateAssetAssertionLink(
+            this.repositoryImplementations[repository],
+            repository,
+            ual,
+            oldAssertionId,
+            newAssertionId,
+        );
+    }
+
     async getAssetAssertionLinks(repository, blockchain, contract, tokenId) {
         const bindings = await this.tripleStoreModuleManager.getAssetAssertionLinks(
             this.repositoryImplementations[repository],
@@ -195,6 +240,17 @@ class TripleStoreService {
             this.ualService.deriveUAL(blockchain, contract, tokenId),
         );
         return this.dataService.parseBindings(bindings);
+    }
+
+    async assetAssertionLinkExists(repository, blockchain, contract, tokenId, assertionId) {
+        const ual = this.ualService.deriveUAL(blockchain, contract, tokenId);
+
+        return this.tripleStoreModuleManager.assetAssertionLinkExists(
+            this.repositoryImplementations[repository],
+            repository,
+            ual,
+            assertionId,
+        );
     }
 
     async assertionExists(repository, assertionId) {


### PR DESCRIPTION
- Splitted ServiceAgreementOpData migration into 2 migrations
    - [Non-Blocking] Inspector (compiling list of the invalid SAs and assertionIds)
    - [Blocking] Fixer
        - Fixing invalid SAs in OP DB and current repositories of the Triple Store
        - Fixing invalid KA Assertion links in the historical repositories of the Triple Store
- Added additional functions for Knowledge Asset Assertion Links manipulation