### PR TITLE
V6/bug fix/scoring function result

### DIFF
--- a/src/service/proximity-scoring-service.js
+++ b/src/service/proximity-scoring-service.js
@@ -103,16 +103,10 @@ class ProximityScoringService {
         const dividend = mappedStake.pow(stakeExponent).mul(a).add(b);
         const divisor = mappedDistance.pow(distanceExponent).mul(c).add(d);
 
-        return {
-            mappedDistance,
-            mappedStake,
-            score: Math.floor(
-                Number(multiplier) *
-                    Math.log2(
-                        Number(logArgumentConstant) + dividend.toNumber() / divisor.toNumber(),
-                    ),
-            ),
-        };
+        return Math.floor(
+            Number(multiplier) *
+                Math.log2(Number(logArgumentConstant) + dividend.toNumber() / divisor.toNumber()),
+        );
     }
 
     async linearSum(

--- a/src/service/proximity-scoring-service.js
+++ b/src/service/proximity-scoring-service.js
@@ -191,7 +191,7 @@ class ProximityScoringService {
             finalScore = finalScore.mod(UINT40_MAX_BN.add(1));
         }
 
-        return finalScore;
+        return finalScore.toNumber();
     }
 }
 


### PR DESCRIPTION
return type of score functions should be a number, but log2pldsf returns an object instead. This obviously affects ranking