### PR TITLE
Add Linux setup script for local network setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ Then, depending on the OS, use one of the scripts in order to run the local netw
 bash ./tools/local-network-setup/setup-macos-environment.sh --nodes=12
 ```
 
+**Linux**
+
+```bash
+./tools/local-network-setup/setup-linux-environment.sh --nodes=12
+```
+
 ---
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ By their nature, Knowledge Assets are semantic resources (following the W3C Sema
 
 <br/>
 
--   **NodeJS** >= 16.0.0
+-   **NodeJS** 16.x (ideally, 16.16)
 -   **npm** >= 8.0.0
 
 ---

--- a/tools/local-network-setup/README.md
+++ b/tools/local-network-setup/README.md
@@ -57,16 +57,16 @@ The first node will be named `bootstrap`, while subsequent nodes will be named `
 ### MacOS
 
 ```bash
-bash ./tools/local-network-setup/setup-macos-environment.sh --nodes=6
+bash ./tools/local-network-setup/setup-macos-environment.sh --nodes=12
 ```
 
 ### Linux
 
 ```bash
-./tools/local-network-setup/setup-linux-environment.sh --nodes=6
+./tools/local-network-setup/setup-linux-environment.sh --nodes=12
 ```
 
-**Note:** With the above command, we will start two hardhat instances, deploy contracts, deploy a 6 nodes network (1 bootstrap and 5 subsequent nodes)<br/>
+**Note:** With the above commands, we will start two hardhat instances, deploy contracts, deploy a 12 node network (1 bootstrap and 11 subsequent nodes)<br/>
 
 ## Specifying the blockchain network
 

--- a/tools/local-network-setup/README.md
+++ b/tools/local-network-setup/README.md
@@ -3,7 +3,7 @@
 This tool will help you set up a local DKG v6 network running with the Hardhat blockchain. It is useful for development and testing purposes and is used internally by the OriginTrail core developers.
 <br/>
 
-**Note: This tool is an internal tool used by the OriginTrail team and thus is developed for our workflow, meaning that it currently only supports MacOS**, but we encourage you to adapt it for your workflow as well.
+**Note: This tool is an internal tool used by the OriginTrail team and thus is developed for our workflow, meaning that it currently only supports MacOS and Linux**, but we encourage you to adapt it for your workflow as well.
 
 # Prerequisites
 
@@ -54,8 +54,16 @@ You can specify to run anywhere between one and twenty nodes with the `--nodes` 
 
 The first node will be named `bootstrap`, while subsequent nodes will be named `dh1, dh2, ...`. <br/>
 
+### MacOS
+
 ```bash
 bash ./tools/local-network-setup/setup-macos-environment.sh --nodes=6
+```
+
+### Linux
+
+```bash
+./tools/local-network-setup/setup-linux-environment.sh --nodes=6
 ```
 
 **Note:** With the above command, we will start two hardhat instances, deploy contracts, deploy a 6 nodes network (1 bootstrap and 5 subsequent nodes)<br/>

--- a/tools/local-network-setup/setup-linux-environment.sh
+++ b/tools/local-network-setup/setup-linux-environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 pathToOtNode=$(pwd)
-numberOfNodes=4
+numberOfNodes=12
 network="hardhat1:31337"
 tripleStore="ot-blazegraph"
 availableNetworks=("hardhat1:31337")

--- a/tools/local-network-setup/setup-linux-environment.sh
+++ b/tools/local-network-setup/setup-linux-environment.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+pathToOtNode=$(pwd)
+numberOfNodes=4
+network="hardhat1:31337"
+tripleStore="ot-blazegraph"
+availableNetworks=("hardhat1:31337")
+export $(xargs < $pathToOtNode/.env)
+export ACCESS_KEY=$RPC_ENDPOINT
+# Check for script arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+  	# Override number of nodes if the argument is specified
+    --nodes=*)
+      numberOfNodes="${1#*=}"
+      if [[ $numberOfNodes -le 0 ]]
+      then
+        echo Cannot run 0 nodes
+        exit 1
+      fi
+      ;;
+    # Print script usage if --help is given
+    --help)
+      echo "Use --nodes=<insert_number_here> to specify the number of nodes to generate"
+      echo "Use --network=<insert_network_name> to specify the network to connect to. Available networks: hardhat."
+      exit 0
+      ;;
+    --network=*)
+      network="${1#*=}"
+      if [[ ! " ${availableNetworks[@]} " =~ " ${network} " ]]
+      then
+          echo Invalid network parameter. Available networks: hardhat
+          exit 1
+      fi
+      ;;
+    --tripleStore=*)
+      tripleStore="${1#*=}"
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument.*\n"
+      printf "***************************\n"
+      exit 1
+  esac
+  shift
+done
+if [[ $network == hardhat1:31337 ]]
+then
+  echo ================================
+  echo ====== Starting hardhat1 ======
+  echo ================================
+  sh -c "cd $pathToOtNode && node tools/local-network-setup/run-local-blockchain.js 8545 :v1" &
+  echo Waiting for hardhat to start and contracts deployment
+
+  echo ================================
+  echo ====== Starting hardhat 2 ======
+  echo ================================
+  sh -c "cd $pathToOtNode && node tools/local-network-setup/run-local-blockchain.js 9545 :v2" &
+  echo Waiting for hardhat to start and contracts deployment
+fi
+
+echo ================================
+echo ====== Generating configs ======
+echo ================================
+
+node $pathToOtNode/tools/local-network-setup/generate-config-files.js $numberOfNodes $network $tripleStore $hubContractAddress
+sleep 5
+echo ================================
+echo ======== Starting nodes ========
+echo ================================
+
+startNode() {
+  echo Starting node $1
+  sh -c "cd $pathToOtNode && node index.js ./tools/local-network-setup/.node$1_origintrail_noderc.json" &
+}
+
+i=0
+while [[ $i -lt $numberOfNodes ]]
+do
+  startNode $i
+  ((i = i + 1))
+done
+
+wait
+# Close started background processes when done (https://stackoverflow.com/a/2173421)
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT

--- a/tools/local-network-setup/setup-macos-environment.sh
+++ b/tools/local-network-setup/setup-macos-environment.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 pathToOtNode=$(pwd)
-numberOfNodes=4
+numberOfNodes=12
 network="hardhat1:31337"
 tripleStore="ot-blazegraph"
 availableNetworks=("hardhat1:31337")


### PR DESCRIPTION
# Description

Add a script for running ot-node(s) in a local network setup on Linux. Based on the existing script for MacOS.

Also, bump recommended number of nodes to `12` from `6` and mark NodeJS 16.x as required in repo REDME.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested on a Ubuntu 22.04 VM by running multiple times.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
