### PR TITLE
Add support for inputting multiple operational wallets

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -267,9 +267,9 @@ install_node() {
 
 # Blockchains prompt based on the selected environment
 if [ "$nodeEnv" == "mainnet" ]; then
-    blockchain_prompt=("OriginTrail Parachain")
+    blockchain_prompt=("OriginTrail Parachain is now NeuroWeb" "Gnosis" "Both")
 elif [ "$nodeEnv" == "testnet" ]; then
-    blockchain_prompt=("OriginTrail Parachain" "Gnosis" "Both")
+    blockchain_prompt=("OriginTrail Parachain is now NeuroWeb" "Gnosis" "Both")
 fi
 
 # Ask user which blockchain to connect to with strict input validation
@@ -318,6 +318,7 @@ case "$blockchain" in
     "Both" )
         if [ "$nodeEnv" == "mainnet" ]; then
             blockchain1="OTP"
+            blockchain2="Gnosis"
         elif [ "$nodeEnv" == "testnet" ]; then
             blockchain1="OTP"
             blockchain2="Gnosis"
@@ -409,6 +410,7 @@ perform_step $(jq --null-input --arg tripleStore "$tripleStore" '{"logLevel": "t
 # Set blockchain IDs based on the environment
 if [ "$nodeEnv" == "mainnet" ]; then
     otp_blockchain_id=2043
+    gnosis_blockchain_id=100
 else
     otp_blockchain_id=20430
     gnosis_blockchain_id=10200

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -323,11 +323,8 @@ done
 case "$blockchain" in
     "OriginTrail Parachain" | "Gnosis" )
         # Input wallets for the selected blockchain
-        read -p "Enter your EVM operational wallet address for $blockchain: " EVM_OPERATIONAL_WALLET
-        text_color $GREEN "EVM operational wallet address for $blockchain: $EVM_OPERATIONAL_WALLET"
-
-        read -p "Enter your EVM operational wallet private key for $blockchain: " EVM_OPERATIONAL_PRIVATE_KEY
-        text_color $GREEN "EVM operational wallet private key for $blockchain: $EVM_OPERATIONAL_PRIVATE_KEY"
+        request_operational_wallet_keys $blockchain
+        EVM_OP_WALLET_KEYS_BLOCKCHAIN=$OP_WALLET_KEYS_JSON
 
         read -p "Enter your EVM management wallet address for $blockchain: " EVM_MANAGEMENT_WALLET
         text_color $GREEN "EVM management wallet address for $blockchain: $EVM_MANAGEMENT_WALLET"
@@ -355,11 +352,8 @@ case "$blockchain" in
         fi
 
         # Input wallets for the first blockchain
-        read -p "Enter your EVM operational wallet address for $blockchain1: " EVM_OPERATIONAL_WALLET
-        text_color $GREEN "EVM operational wallet address for $blockchain1: $EVM_OPERATIONAL_WALLET"
-
-        read -p "Enter your EVM operational wallet private key for $blockchain1: " EVM_OPERATIONAL_PRIVATE_KEY
-        text_color $GREEN "EVM operational wallet private key for $blockchain1: $EVM_OPERATIONAL_PRIVATE_KEY"
+        request_operational_wallet_keys $blockchain1
+        EVM_OP_WALLET_KEYS_BLOCKCHAIN1=$OP_WALLET_KEYS_JSON
 
         read -p "Enter your EVM management wallet address for $blockchain1: " EVM_MANAGEMENT_WALLET
         text_color $GREEN "EVM management wallet address for $blockchain1: $EVM_MANAGEMENT_WALLET"
@@ -371,11 +365,8 @@ case "$blockchain" in
         text_color $GREEN "Profile shares token symbol for $blockchain1: $SHARES_TOKEN_SYMBOL"
 
         # Input wallets for the second blockchain
-        read -p "Enter your EVM operational wallet address for $blockchain2: " EVM_OPERATIONAL_WALLET_2
-        text_color $GREEN "EVM operational wallet address for $blockchain2: $EVM_OPERATIONAL_WALLET_2"
-
-        read -p "Enter your EVM operational wallet private key for $blockchain2: " EVM_OPERATIONAL_PRIVATE_KEY_2
-        text_color $GREEN "EVM operational wallet private key for $blockchain2: $EVM_OPERATIONAL_PRIVATE_KEY_2"
+        request_operational_wallet_keys $blockchain2
+        EVM_OP_WALLET_KEYS_BLOCKCHAIN2=$OP_WALLET_KEYS_JSON
 
         read -p "Enter your EVM management wallet address for $blockchain2: " EVM_MANAGEMENT_WALLET_2
         text_color $GREEN "EVM management wallet address for $blockchain2: $EVM_MANAGEMENT_WALLET_2"
@@ -448,13 +439,12 @@ fi
 
 # Check if "Both" blockchains are selected
 if [ "$blockchain" == "Both" ]; then
-  perform_step $(jq --arg otp_blockchain_id "$otp_blockchain_id" --arg EVM_OPERATIONAL_WALLET "$EVM_OPERATIONAL_WALLET" --arg EVM_OPERATIONAL_PRIVATE_KEY "$EVM_OPERATIONAL_PRIVATE_KEY" --arg EVM_MANAGEMENT_WALLET "$EVM_MANAGEMENT_WALLET" --arg SHARES_TOKEN_NAME "$SHARES_TOKEN_NAME" --arg SHARES_TOKEN_SYMBOL "$SHARES_TOKEN_SYMBOL" --arg gnosis_blockchain_id "$gnosis_blockchain_id" --arg EVM_OPERATIONAL_WALLET_2 "$EVM_OPERATIONAL_WALLET_2" --arg EVM_OPERATIONAL_PRIVATE_KEY_2 "$EVM_OPERATIONAL_PRIVATE_KEY_2" --arg EVM_MANAGEMENT_WALLET_2 "$EVM_MANAGEMENT_WALLET_2" --arg SHARES_TOKEN_NAME_2 "$SHARES_TOKEN_NAME_2" --arg SHARES_TOKEN_SYMBOL_2 "$SHARES_TOKEN_SYMBOL_2" --arg GNOSIS_RPC_ENDPOINT "$GNOSIS_RPC_ENDPOINT" '
+  perform_step $(jq --arg otp_blockchain_id "$otp_blockchain_id" --argjson EVM_OP_WALLET_KEYS_BLOCKCHAIN1 "$EVM_OP_WALLET_KEYS_BLOCKCHAIN1" --argjson EVM_OP_WALLET_KEYS_BLOCKCHAIN2 "$EVM_OP_WALLET_KEYS_BLOCKCHAIN2" --arg EVM_MANAGEMENT_WALLET "$EVM_MANAGEMENT_WALLET" --arg SHARES_TOKEN_NAME "$SHARES_TOKEN_NAME" --arg SHARES_TOKEN_SYMBOL "$SHARES_TOKEN_SYMBOL" --arg gnosis_blockchain_id "$gnosis_blockchain_id" --arg EVM_OPERATIONAL_WALLET_2 "$EVM_OPERATIONAL_WALLET_2" --arg EVM_OPERATIONAL_PRIVATE_KEY_2 "$EVM_OPERATIONAL_PRIVATE_KEY_2" --arg EVM_MANAGEMENT_WALLET_2 "$EVM_MANAGEMENT_WALLET_2" --arg SHARES_TOKEN_NAME_2 "$SHARES_TOKEN_NAME_2" --arg SHARES_TOKEN_SYMBOL_2 "$SHARES_TOKEN_SYMBOL_2" --arg GNOSIS_RPC_ENDPOINT "$GNOSIS_RPC_ENDPOINT" '
     .modules.blockchain.implementation += {
       "otp:'$otp_blockchain_id'": {
         "enabled": true,
         "config": {
-          "evmOperationalWalletPublicKey": $EVM_OPERATIONAL_WALLET,
-          "evmOperationalWalletPrivateKey": $EVM_OPERATIONAL_PRIVATE_KEY,
+          "operationalWallets": $EVM_OP_WALLET_KEYS_BLOCKCHAIN1,
           "evmManagementWalletPublicKey": $EVM_MANAGEMENT_WALLET,
           "sharesTokenName": $SHARES_TOKEN_NAME,
           "sharesTokenSymbol": $SHARES_TOKEN_SYMBOL
@@ -463,8 +453,7 @@ if [ "$blockchain" == "Both" ]; then
       "gnosis:'$gnosis_blockchain_id'": {
         "enabled": true,
         "config": {
-          "evmOperationalWalletPublicKey": $EVM_OPERATIONAL_WALLET_2,
-          "evmOperationalWalletPrivateKey": $EVM_OPERATIONAL_PRIVATE_KEY_2,
+          "operationalWallets": $EVM_OP_WALLET_KEYS_BLOCKCHAIN2,
           "evmManagementWalletPublicKey": $EVM_MANAGEMENT_WALLET_2,
           "sharesTokenName": $SHARES_TOKEN_NAME_2,
           "sharesTokenSymbol": $SHARES_TOKEN_SYMBOL_2,
@@ -491,8 +480,7 @@ else
   blockchain_arg="$blockchain:$blockchain_id"
 
 jq --arg blockchain_arg "$blockchain_arg" \
-   --arg EVM_OPERATIONAL_WALLET "$EVM_OPERATIONAL_WALLET" \
-   --arg EVM_OPERATIONAL_PRIVATE_KEY "$EVM_OPERATIONAL_PRIVATE_KEY" \
+   --argjson EVM_OP_WALLET_KEYS_BLOCKCHAIN "$EVM_OP_WALLET_KEYS_BLOCKCHAIN" \
    --arg EVM_MANAGEMENT_WALLET "$EVM_MANAGEMENT_WALLET" \
    --arg SHARES_TOKEN_NAME "$SHARES_TOKEN_NAME" \
    --arg SHARES_TOKEN_SYMBOL "$SHARES_TOKEN_SYMBOL" \
@@ -502,8 +490,7 @@ jq --arg blockchain_arg "$blockchain_arg" \
   ($blockchain_arg): {
     "enabled": true,
     "config": {
-      "evmOperationalWalletPublicKey": $EVM_OPERATIONAL_WALLET,
-      "evmOperationalWalletPrivateKey": $EVM_OPERATIONAL_PRIVATE_KEY,
+      "operationalWallets": $EVM_OP_WALLET_KEYS_BLOCKCHAIN,
       "evmManagementWalletPublicKey": $EVM_MANAGEMENT_WALLET,
       "sharesTokenName": $SHARES_TOKEN_NAME,
       "sharesTokenSymbol": $SHARES_TOKEN_SYMBOL

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -267,9 +267,9 @@ install_node() {
 
 # Blockchains prompt based on the selected environment
 if [ "$nodeEnv" == "mainnet" ]; then
-    blockchain_prompt=("OriginTrail Parachain is now NeuroWeb" "Gnosis" "Both")
+    blockchain_prompt=("OriginTrail Parachain" "Gnosis" "Both")
 elif [ "$nodeEnv" == "testnet" ]; then
-    blockchain_prompt=("OriginTrail Parachain is now NeuroWeb" "Gnosis" "Both")
+    blockchain_prompt=("OriginTrail Parachain" "Gnosis" "Both")
 fi
 
 # Ask user which blockchain to connect to with strict input validation

--- a/tools/local-network-setup/.origintrail_noderc_template.json
+++ b/tools/local-network-setup/.origintrail_noderc_template.json
@@ -140,17 +140,25 @@
                     "enabled": true,
                     "package": "./blockchain/implementation/hardhat/hardhat-service.js",
                     "config": {
-                        "evmOperationalWalletPublicKey": "0xd6879C0A03aDD8cFc43825A42a3F3CF44DB7D2b9",
-                        "rpcEndpoints": [],
-                        "evmOperationalWalletPrivateKey": "0x02b39cac1532bef9dba3e36ec32d3de1e9a88f1dda597d3ac6e2130aed9adc4e"
+                        "operationalWallets": [
+                            {
+                                "evmAddress": "0xd6879C0A03aDD8cFc43825A42a3F3CF44DB7D2b9",
+                                "privateKey": "0x02b39cac1532bef9dba3e36ec32d3de1e9a88f1dda597d3ac6e2130aed9adc4e"
+                            }
+                        ],
+                        "rpcEndpoints": []
                     }
                 },
                 "hardhat2:31337": {
                     "package": "./blockchain/implementation/hardhat/hardhat-service.js",
                     "config": {
-                        "evmOperationalWalletPublicKey": "0xd6879C0A03aDD8cFc43825A42a3F3CF44DB7D2b9",
-                        "rpcEndpoints": [],
-                        "evmOperationalWalletPrivateKey": "0x02b39cac1532bef9dba3e36ec32d3de1e9a88f1dda597d3ac6e2130aed9adc4e"
+                        "operationalWallets": [
+                            {
+                                "evmAddress": "0xd6879C0A03aDD8cFc43825A42a3F3CF44DB7D2b9",
+                                "privateKey": "0x02b39cac1532bef9dba3e36ec32d3de1e9a88f1dda597d3ac6e2130aed9adc4e"
+                            }
+                        ],
+                        "rpcEndpoints": []
                     }
                 }
             }

--- a/tools/local-network-setup/generate-config-files.js
+++ b/tools/local-network-setup/generate-config-files.js
@@ -132,6 +132,31 @@ function generateBlockchainConfig(templateBlockchainConfig, nodeIndex) {
         sharesTokenSymbol: `LN${nodeIndex}`,
     };
 
+    // Used for testing, add a few more wallets to later nodes
+    if (nodeIndex == 3) {
+        blockchainConfig.implementation['hardhat1:31337'].config.operationalWallets.push({
+            evmAddress: publicKeys[publicKeys.length - 1 - 1],
+            privateKey: privateKeys[privateKeys.length - 1 - 1],
+        });
+
+        blockchainConfig.implementation['hardhat2:31337'].config.operationalWallets.push({
+            evmAddress: publicKeys[publicKeys.length - 1 - 2],
+            privateKey: privateKeys[privateKeys.length - 1 - 2],
+        });
+    }
+
+    if (nodeIndex == 4) {
+        blockchainConfig.implementation['hardhat1:31337'].config.operationalWallets.push({
+            evmAddress: publicKeys[publicKeys.length - 1 - 3],
+            privateKey: privateKeys[privateKeys.length - 1 - 3],
+        });
+
+        blockchainConfig.implementation['hardhat2:31337'].config.operationalWallets.push({
+            evmAddress: publicKeys[publicKeys.length - 1 - 4],
+            privateKey: privateKeys[privateKeys.length - 1 - 4],
+        });
+    }
+
     return blockchainConfig;
 }
 

--- a/tools/local-network-setup/generate-config-files.js
+++ b/tools/local-network-setup/generate-config-files.js
@@ -103,8 +103,12 @@ function generateBlockchainConfig(templateBlockchainConfig, nodeIndex) {
         ...blockchainConfig.implementation['hardhat1:31337'].config,
         hubContractAddress,
         rpcEndpoints: [process.env.RPC_ENDPOINT_BC1],
-        evmOperationalWalletPublicKey: publicKeys[nodeIndex],
-        evmOperationalWalletPrivateKey: privateKeys[nodeIndex],
+        operationalWallets: [
+            {
+                evmAddress: publicKeys[nodeIndex],
+                privateKey: privateKeys[nodeIndex],
+            },
+        ],
         evmManagementWalletPublicKey: publicKeys[publicKeys.length - 1 - nodeIndex],
         evmManagementWalletPrivateKey: privateKeys[privateKeys.length - 1 - nodeIndex],
         sharesTokenName: `LocalNode${nodeIndex}`,
@@ -116,8 +120,12 @@ function generateBlockchainConfig(templateBlockchainConfig, nodeIndex) {
         ...blockchainConfig.implementation['hardhat2:31337'].config,
         hubContractAddress,
         rpcEndpoints: [process.env.RPC_ENDPOINT_BC2],
-        evmOperationalWalletPublicKey: publicKeys[nodeIndex],
-        evmOperationalWalletPrivateKey: privateKeys[nodeIndex],
+        operationalWallets: [
+            {
+                evmAddress: publicKeys[nodeIndex],
+                privateKey: privateKeys[nodeIndex],
+            },
+        ],
         evmManagementWalletPublicKey: publicKeys[publicKeys.length - 1 - nodeIndex],
         evmManagementWalletPrivateKey: privateKeys[privateKeys.length - 1 - nodeIndex],
         sharesTokenName: `LocalNode${nodeIndex}`,


### PR DESCRIPTION
# Description

Add support for inputting multiple operational wallets (public and private keys) to the installer and local-network-setup. Based on #2952, will rebase if needed.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested on an Ubuntu 22.04 system by running multiple times.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
