### PR TITLE
add overflow warnings to linear sum, fix max distance calculation

### DIFF
--- a/src/service/proximity-scoring-service.js
+++ b/src/service/proximity-scoring-service.js
@@ -156,6 +156,9 @@ class ProximityScoringService {
 
         let normalizedDistance = scaledDistance.div(adjustedDivisor);
         if (normalizedDistance.gt(UINT64_MAX_BN)) {
+            this.logger.warn(
+                `Invalid normalized distance: ${normalizedDistance.toString()}. Max value: ${UINT64_MAX_BN.toString()}`,
+            );
             normalizedDistance = normalizedDistance.mod(UINT64_MAX_BN.add(1));
         }
 
@@ -163,6 +166,9 @@ class ProximityScoringService {
             .mul(mappedStake.sub(mappedMinStake))
             .div(mappedMaxStake.sub(mappedMinStake));
         if (normalizedStake.gt(UINT64_MAX_BN)) {
+            this.logger.warn(
+                `Invalid normalized stake: ${normalizedDistance.toString()}. Max value: ${UINT64_MAX_BN.toString()}`,
+            );
             normalizedStake = normalizedStake.mod(UINT64_MAX_BN.add(1));
         }
 

--- a/src/service/service-agreement-service.js
+++ b/src/service/service-agreement-service.js
@@ -90,12 +90,11 @@ class ServiceAgreementService {
         );
         let maxNeighborhoodDistance;
         if (neighbourhoodEdges) {
-            maxNeighborhoodDistance = await this.proximityScoringService.callProximityFunction(
-                blockchainId,
-                proximityScoreFunctionsPairId,
-                neighbourhoodEdges.leftEdge[hashFunctionName],
-                neighbourhoodEdges.rightEdge[hashFunctionName],
-            );
+            maxNeighborhoodDistance = neighbourhoodEdges.leftEdge.distance.gt(
+                neighbourhoodEdges.rightEdge.distance,
+            )
+                ? neighbourhoodEdges.leftEdge.distance
+                : neighbourhoodEdges.rightEdge.distance;
         }
 
         return this.proximityScoringService.callScoreFunction(

--- a/src/service/sharding-table-service.js
+++ b/src/service/sharding-table-service.js
@@ -140,7 +140,7 @@ class ShardingTableService {
         const hashFunctionName = this.hashingService.getHashFunctionName(hashFunctionId);
         const peersWithDistance = await Promise.all(
             peers.map(async (peer) => ({
-                peer,
+                ...peer,
                 distance: await this.proximityScoringService.callProximityFunction(
                     blockchainId,
                     proximityScoreFunctionsPairId,
@@ -158,8 +158,7 @@ class ShardingTableService {
             }
             return 0;
         });
-        const result = peersWithDistance.slice(0, count).map((pd) => pd.peer);
-        return result;
+        return peersWithDistance.slice(0, count);
     }
 
     async getBidSuggestion(


### PR DESCRIPTION
I've added warnings in case distance and stake are greater than uint64, as this should never happen, but currently there is no way to notice if it does.
I've fixed the max distance calculation, as it calculates the distance between the nodes at the edges instead of finding the max distance of the neighborhood.