### PR TITLE
[OPTIONAL IMPROVEMENT] SA table indexes

### DIFF
--- a/src/modules/repository/implementation/sequelize/migrations/20240216184100-add-service-agreement-indexes.js
+++ b/src/modules/repository/implementation/sequelize/migrations/20240216184100-add-service-agreement-indexes.js
@@ -1,0 +1,40 @@
+export async function up({ context: { queryInterface } }) {
+    // Composite index for common columns used in calculations and conditions
+    await queryInterface.addIndex(
+        'service_agreements',
+        ['blockchainId', 'start_time', 'epoch_length'],
+        {
+            name: 'idx_sa_common_fields',
+        },
+    );
+
+    // Indexes for getEligibleAgreementsForSubmitCommit
+    await queryInterface.addIndex('service_agreements', ['blockchainId', 'lastCommitEpoch'], {
+        name: 'idx_sa_commit_blockchain_commit_epoch',
+    });
+
+    await queryInterface.addIndex('service_agreements', ['epochsNumber'], {
+        name: 'idx_sa_commit_epochs_number',
+    });
+
+    // Indexes for getEligibleAgreementsForSubmitProof
+    await queryInterface.addIndex(
+        'service_agreements',
+        ['blockchainId', 'lastCommitEpoch', 'lastProofEpoch'],
+        {
+            name: 'idx_sa_proof_commit_proof_epoch',
+        },
+    );
+
+    await queryInterface.addIndex('service_agreements', ['proofWindowOffsetPerc'], {
+        name: 'idx_sa_proof_window_offset_perc',
+    });
+}
+
+export async function down({ context: { queryInterface } }) {
+    await queryInterface.removeIndex('service_agreements', 'idx_sa_proof_window_offset_perc');
+    await queryInterface.removeIndex('service_agreements', 'idx_sa_proof_commit_proof_epoch');
+    await queryInterface.removeIndex('service_agreements', 'idx_sa_commit_epochs_number');
+    await queryInterface.removeIndex('service_agreements', 'idx_sa_commit_blockchain_commit_epoch');
+    await queryInterface.removeIndex('service_agreements', 'idx_sa_common_fields');
+}

--- a/src/modules/repository/implementation/sequelize/migrations/20240216184100-add-service-agreement-indexes.js
+++ b/src/modules/repository/implementation/sequelize/migrations/20240216184100-add-service-agreement-indexes.js
@@ -1,7 +1,7 @@
 export async function up({ context: { queryInterface } }) {
     // Composite index for common columns used in calculations and conditions
     await queryInterface.addIndex(
-        'service_agreements',
+        'service_agreement',
         ['blockchainId', 'start_time', 'epoch_length'],
         {
             name: 'idx_sa_common_fields',
@@ -9,32 +9,37 @@ export async function up({ context: { queryInterface } }) {
     );
 
     // Indexes for getEligibleAgreementsForSubmitCommit
-    await queryInterface.addIndex('service_agreements', ['blockchainId', 'lastCommitEpoch'], {
+    await queryInterface.addIndex('service_agreement', ['bid'], {
+        name: 'idx_sa_bid',
+    });
+
+    await queryInterface.addIndex('service_agreement', ['blockchainId', 'lastCommitEpoch'], {
         name: 'idx_sa_commit_blockchain_commit_epoch',
     });
 
-    await queryInterface.addIndex('service_agreements', ['epochsNumber'], {
+    await queryInterface.addIndex('service_agreement', ['epochsNumber'], {
         name: 'idx_sa_commit_epochs_number',
     });
 
     // Indexes for getEligibleAgreementsForSubmitProof
     await queryInterface.addIndex(
-        'service_agreements',
+        'service_agreement',
         ['blockchainId', 'lastCommitEpoch', 'lastProofEpoch'],
         {
             name: 'idx_sa_proof_commit_proof_epoch',
         },
     );
 
-    await queryInterface.addIndex('service_agreements', ['proofWindowOffsetPerc'], {
+    await queryInterface.addIndex('service_agreement', ['proofWindowOffsetPerc'], {
         name: 'idx_sa_proof_window_offset_perc',
     });
 }
 
 export async function down({ context: { queryInterface } }) {
-    await queryInterface.removeIndex('service_agreements', 'idx_sa_proof_window_offset_perc');
-    await queryInterface.removeIndex('service_agreements', 'idx_sa_proof_commit_proof_epoch');
-    await queryInterface.removeIndex('service_agreements', 'idx_sa_commit_epochs_number');
-    await queryInterface.removeIndex('service_agreements', 'idx_sa_commit_blockchain_commit_epoch');
-    await queryInterface.removeIndex('service_agreements', 'idx_sa_common_fields');
+    await queryInterface.removeIndex('service_agreement', 'idx_sa_proof_window_offset_perc');
+    await queryInterface.removeIndex('service_agreement', 'idx_sa_proof_commit_proof_epoch');
+    await queryInterface.removeIndex('service_agreement', 'idx_sa_commit_epochs_number');
+    await queryInterface.removeIndex('service_agreement', 'idx_sa_commit_blockchain_commit_epoch');
+    await queryInterface.removeIndex('service_agreement', 'idx_sa_common_fields');
+    await queryInterface.removeIndex('service_agreement', 'idx_sa_bid');
 }


### PR DESCRIPTION
Optional improvement with migration for `service_agreements` table in the operational db that should improve speed of the queries used in `EpochCheckCommand`.

However, it will slow down write operations as indexes need to be updated, so this should be used only if some performance degradation is visible when having huge amount of SAs in the DB.