### PR TITLE
update gnosis gas price oracle, fix gas price function

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -753,7 +753,7 @@
                         "package": "./blockchain/implementation/gnosis/gnosis-service.js",
                         "config": {
                             "hubContractAddress": "0xbEF14fc04F870c2dD65c13Df4faB6ba01A9c746b",
-                            "gasPriceOracleLink": "https://api.gnosisscan.io/api?module=proxy&action=eth_gasPrice",
+                            "gasPriceOracleLink": "https://gnosis.blockscout.com/api/v1/gas-price-oracle",
                             "operatorFee": 0
                         }
                     }

--- a/src/modules/blockchain/implementation/gnosis/gnosis-service.js
+++ b/src/modules/blockchain/implementation/gnosis/gnosis-service.js
@@ -26,9 +26,7 @@ class GnosisService extends Web3Service {
                     : GNOSIS_DEFAULT_GAS_PRICE.TESTNET;
         try {
             const response = await axios.get(this.config.gasPriceOracleLink);
-            if (response?.data?.average) {
-                gasPrice = response?.data?.average;
-            }
+            gasPrice = response?.data?.average;
             this.logger.debug(`Gas price from Gnosis oracle link: ${gasPrice} gwei`);
         } catch (error) {
             this.logger.warn(

--- a/src/modules/blockchain/implementation/gnosis/gnosis-service.js
+++ b/src/modules/blockchain/implementation/gnosis/gnosis-service.js
@@ -19,26 +19,24 @@ class GnosisService extends Web3Service {
     }
 
     async getGasPrice() {
-        try {
-            const response = await axios.get(this.config.gasPriceOracleLink);
-            let gasPrice;
-            if (this.config.name.split(':')[1] === '100') {
-                gasPrice = Number(response.data.result, 10);
-            } else if (this.config.name.split(':')[1] === '10200') {
-                gasPrice = Math.round(response.data.average * 1e9);
-            }
-            this.logger.debug(`Gas price on Gnosis: ${gasPrice}`);
-            return gasPrice;
-        } catch (error) {
-            const defaultGasPrice =
+        let gasPrice;
+        const defaultGasPrice =
                 process.env.NODE_ENV === NODE_ENVIRONMENTS.MAINNET
                     ? GNOSIS_DEFAULT_GAS_PRICE.MAINNET
                     : GNOSIS_DEFAULT_GAS_PRICE.TESTNET;
+        try {
+            const response = await axios.get(this.config.gasPriceOracleLink);
+            if (response?.data?.average) {
+                gasPrice = response?.data?.average;
+            }
+            this.logger.debug(`Gas price from Gnosis oracle link: ${gasPrice} gwei`);
+        } catch (error) {
             this.logger.warn(
                 `Failed to fetch the gas price from the Gnosis: ${error}. Using default value: ${defaultGasPrice} Gwei.`,
             );
-            this.convertToWei(defaultGasPrice, 'gwei');
         }
+
+        return this.convertToWei(gasPrice ?? defaultGasPrice, 'gwei');
     }
 
     async healthCheck() {


### PR DESCRIPTION
gas price used for gnosis transactions is currently 20 gwei (default in web3-service.js). Fixed getGasPrice function to correctly fetch gas price from the oracle link or return 5 gwei  in case of error