### PR TITLE
add executeUalExtensionTripleStoreMigration on node start

### DIFF
--- a/ot-node.js
+++ b/ot-node.js
@@ -68,6 +68,12 @@ class OTNode {
             this.config,
         );
 
+        await MigrationExecutor.executeUalExtensionTripleStoreMigration(
+            this.container,
+            this.logger,
+            this.config,
+        );
+
         await this.initializeBlockchainEventListenerService();
 
         await MigrationExecutor.executePullShardingTableMigration(


### PR DESCRIPTION
Epoch check command is postponed indefinitely as executeUalExtensionTripleStoreMigration is never run on new nodes. The alternative is to remove the check in epoch check command, but that would break nodes updating from older versions.