### PR TITLE
Fix gnosis getGasPrice functio and add suport for different oracles

### DIFF
--- a/src/modules/blockchain/implementation/gnosis/gnosis-service.js
+++ b/src/modules/blockchain/implementation/gnosis/gnosis-service.js
@@ -22,9 +22,9 @@ class GnosisService extends Web3Service {
         try {
             const response = await axios.get(this.config.gasPriceOracleLink);
             let gasPrice;
-            if (this.config.name.split(':')[1] === '100') {
+            if (this.getBlockchainId.split(':')[1] === '100') {
                 gasPrice = Number(response.data.result, 10);
-            } else if (this.config.name.split(':')[1] === '10200') {
+            } else if (this.getBlockchainId.split(':')[1] === '10200') {
                 gasPrice = Math.round(response.data.average * 1e9);
             }
             this.logger.debug(`Gas price on Gnosis: ${gasPrice}`);

--- a/src/modules/blockchain/implementation/gnosis/gnosis-service.js
+++ b/src/modules/blockchain/implementation/gnosis/gnosis-service.js
@@ -19,26 +19,34 @@ class GnosisService extends Web3Service {
     }
 
     async getGasPrice() {
+        let gasPrice;
         try {
             const response = await axios.get(this.config.gasPriceOracleLink);
-            let gasPrice;
-            if (this.getBlockchainId.split(':')[1] === '100') {
+            if (response?.data?.average) {
+                // Returnts gwei
+                gasPrice = Number(response.data.average);
+                this.logger.debug(`Gas price from Gnosis oracle link: ${gasPrice} gwei`);
+            } else if (response?.data?.result) {
+                // Returns wei
                 gasPrice = Number(response.data.result, 10);
-            } else if (this.getBlockchainId.split(':')[1] === '10200') {
-                gasPrice = Math.round(response.data.average * 1e9);
+                this.logger.debug(`Gas price from Gnosis oracle link: ${gasPrice} wei`);
+                return gasPrice;
+            } else {
+                throw Error(
+                    `Gas price oracle: ${this.config.gasPriceOracleLink} returns gas price in unsupported format.`,
+                );
             }
-            this.logger.debug(`Gas price on Gnosis: ${gasPrice}`);
-            return gasPrice;
         } catch (error) {
             const defaultGasPrice =
-                process.env.NODE_ENV === NODE_ENVIRONMENTS.MAINNET
+                process.NODE_ENV === NODE_ENVIRONMENTS.MAINNET
                     ? GNOSIS_DEFAULT_GAS_PRICE.MAINNET
                     : GNOSIS_DEFAULT_GAS_PRICE.TESTNET;
             this.logger.warn(
                 `Failed to fetch the gas price from the Gnosis: ${error}. Using default value: ${defaultGasPrice} Gwei.`,
             );
-            this.convertToWei(defaultGasPrice, 'gwei');
+            gasPrice = defaultGasPrice;
         }
+        return this.convertToWei(gasPrice, 'gwei');
     }
 
     async healthCheck() {


### PR DESCRIPTION
# Description

Fixed getGasPrice in gnosis-service to return default gasPrice.
Added support for both https://api.gnosisscan.io/api?module=proxy&action=eth_gasPrice and https://api.gnosisscan.io/api?module=proxy&action=eth_gasPrice gas price oracles, and defaulting to predefined value when oracle returns unsupported format.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran function as a local script to see if it returns correct values.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
