### PR TITLE
Added UalExtensionTripleStoreMigration on startup

### DIFF
--- a/ot-node.js
+++ b/ot-node.js
@@ -68,12 +68,6 @@ class OTNode {
             this.config,
         );
 
-        await MigrationExecutor.executeUalExtensionTripleStoreMigration(
-            this.container,
-            this.logger,
-            this.config,
-        );
-
         await this.initializeBlockchainEventListenerService();
 
         await MigrationExecutor.executePullShardingTableMigration(

--- a/ot-node.js
+++ b/ot-node.js
@@ -68,6 +68,12 @@ class OTNode {
             this.config,
         );
 
+        await MigrationExecutor.executeUalExtensionTripleStoreMigration(
+            this.container,
+            this.logger,
+            this.config,
+        );
+
         await this.initializeBlockchainEventListenerService();
 
         await MigrationExecutor.executePullShardingTableMigration(

--- a/src/commands/protocols/common/epoch-check-command.js
+++ b/src/commands/protocols/common/epoch-check-command.js
@@ -6,9 +6,7 @@ import {
     TRANSACTION_CONFIRMATIONS,
     OPERATION_ID_STATUS,
     ERROR_TYPE,
-    NODE_ENVIRONMENTS,
 } from '../../../constants/constants.js';
-import MigrationExecutor from '../../../migration/migration-executor.js';
 
 class EpochCheckCommand extends Command {
     constructor(ctx) {
@@ -27,20 +25,6 @@ class EpochCheckCommand extends Command {
     }
 
     async execute(command) {
-        const migrationExecuted = await MigrationExecutor.migrationAlreadyExecuted(
-            'ualExtensionTripleStoreMigration',
-            this.fileService,
-        );
-        if (
-            process.env.NODE_ENV !== NODE_ENVIRONMENTS.DEVELOPMENT &&
-            process.env.NODE_ENV !== NODE_ENVIRONMENTS.TEST &&
-            !migrationExecuted
-        ) {
-            this.logger.info(
-                'Epoch check: command will be postponed until ual extension triple store migration is completed',
-            );
-            return Command.repeat();
-        }
         this.logger.info('Epoch check: Starting epoch check command');
         const operationId = this.operationIdService.generateId();
 


### PR DESCRIPTION
# Description

New nodes can't start because they are missing UalExtensionTripleStoreMigration file, so this PR will remove check for this migration in epoch check command. 

UPDATED: Instead of adding migration, check for migration is removed now that multiple versions passed since it being added, and the node isn't going to be blocked.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
