### PR TITLE
fix: dial peers and cache peer ids logic

### DIFF
--- a/src/modules/repository/implementation/sequelize/repositories/shard-repository.js
+++ b/src/modules/repository/implementation/sequelize/repositories/shard-repository.js
@@ -81,6 +81,7 @@ class ShardRepository {
                 },
             },
             order: [['last_dialed', 'asc']],
+            group: ['peer_id', 'last_dialed'],
             limit,
             raw: true,
         });

--- a/src/service/sharding-table-service.js
+++ b/src/service/sharding-table-service.js
@@ -235,23 +235,24 @@ class ShardingTableService {
 
         if (!this.memoryCachedPeerIds[peerId]) {
             this.memoryCachedPeerIds[peerId] = {
-                lastUpdated: 0,
                 lastDialed: 0,
                 lastSeen: 0,
             };
         }
-        if (this.memoryCachedPeerIds[peerId].lastUpdated < timestampThreshold) {
+        if (
+            this.memoryCachedPeerIds[peerId].lastSeen < timestampThreshold ||
+            this.memoryCachedPeerIds[peerId].lastDialed < timestampThreshold
+        ) {
             const [rowsUpdated] =
                 await this.repositoryModuleManager.updatePeerRecordLastSeenAndLastDialed(
                     peerId,
                     now,
                 );
             if (rowsUpdated) {
-                this.memoryCachedPeerIds[peerId].lastUpdated = now;
+                this.memoryCachedPeerIds[peerId].lastDialed = now;
+                this.memoryCachedPeerIds[peerId].lastSeen = now;
             }
         }
-        this.memoryCachedPeerIds[peerId].lastDialed = now;
-        this.memoryCachedPeerIds[peerId].lastSeen = now;
     }
 
     async updatePeerRecordLastDialed(peerId) {
@@ -259,21 +260,19 @@ class ShardingTableService {
         const timestampThreshold = now - PEER_RECORD_UPDATE_DELAY;
         if (!this.memoryCachedPeerIds[peerId]) {
             this.memoryCachedPeerIds[peerId] = {
-                lastUpdated: 0,
                 lastDialed: 0,
                 lastSeen: 0,
             };
         }
-        if (this.memoryCachedPeerIds[peerId].lastUpdated < timestampThreshold) {
+        if (this.memoryCachedPeerIds[peerId].lastDialed < timestampThreshold) {
             const [rowsUpdated] = await this.repositoryModuleManager.updatePeerRecordLastDialed(
                 peerId,
                 now,
             );
             if (rowsUpdated) {
-                this.memoryCachedPeerIds[peerId].lastUpdated = now;
+                this.memoryCachedPeerIds[peerId].lastDialed = now;
             }
         }
-        this.memoryCachedPeerIds[peerId].lastDialed = now;
     }
 
     async findPeerAddressAndProtocols(peerId) {


### PR DESCRIPTION
Fixed issue where dial peers command dials peers multiple times if they are in more than one blockchain's sharding table.
Fixed issue where peers last seen value is not updated correctly.