### PR TITLE
fix: schedule submit commits only if node in sharding table

### DIFF
--- a/src/commands/protocols/common/epoch-check/blockchain-epoch-check-command.js
+++ b/src/commands/protocols/common/epoch-check/blockchain-epoch-check-command.js
@@ -119,6 +119,8 @@ class BlockchainEpochCheckCommand extends Command {
             blockchain,
         );
 
+        if (peerRecord == null) return;
+
         const ask = this.blockchainModuleManager.convertToWei(blockchain, peerRecord.ask);
 
         const timestamp = await this.blockchainModuleManager.getBlockchainTimestamp(blockchain);

--- a/src/commands/protocols/common/epoch-check/blockchain-epoch-check-command.js
+++ b/src/commands/protocols/common/epoch-check/blockchain-epoch-check-command.js
@@ -137,40 +137,40 @@ class BlockchainEpochCheckCommand extends Command {
         const scheduleSubmitCommitCommands = [];
         const updateServiceAgreementsLastCommitEpoch = [];
         for (const serviceAgreement of eligibleAgreementForSubmitCommit) {
-            if (scheduleSubmitCommitCommands.length >= maxTransactions) {
-                this.logger.warn(
-                    `Epoch check: not scheduling new commits. Submit commit command length: ${scheduleSubmitCommitCommands.length}, max number of transactions: ${maxTransactions} for blockchain: ${blockchain}`,
-                );
-                break;
-            }
+            try {
+                if (scheduleSubmitCommitCommands.length >= maxTransactions) {
+                    this.logger.warn(
+                        `Epoch check: not scheduling new commits. Submit commit command length: ${scheduleSubmitCommitCommands.length}, max number of transactions: ${maxTransactions} for blockchain: ${blockchain}`,
+                    );
+                    break;
+                }
 
-            const neighbourhood = await this.shardingTableService.findNeighbourhood(
-                blockchain,
-                serviceAgreement.keyword,
-                r2,
-                serviceAgreement.hashFunctionId,
-                serviceAgreement.scoreFunctionId,
-            );
-
-            let neighbourhoodEdges = null;
-            if (serviceAgreement.scoreFunctionId === 2) {
-                neighbourhoodEdges = await this.shardingTableService.getNeighboorhoodEdgeNodes(
-                    neighbourhood,
+                const neighbourhood = await this.shardingTableService.findNeighbourhood(
                     blockchain,
+                    serviceAgreement.keyword,
+                    r2,
                     serviceAgreement.hashFunctionId,
                     serviceAgreement.scoreFunctionId,
-                    serviceAgreement.keyword,
                 );
-            }
 
-            if (!neighbourhoodEdges && serviceAgreement.scoreFunctionId === 2) {
-                this.logger.warn(
-                    `Epoch check: unable to find neighbourhood edges for agreement id: ${serviceAgreement.agreementId} for blockchain: ${blockchain}`,
-                );
-                continue;
-            }
+                let neighbourhoodEdges = null;
+                if (serviceAgreement.scoreFunctionId === 2) {
+                    neighbourhoodEdges = await this.shardingTableService.getNeighboorhoodEdgeNodes(
+                        neighbourhood,
+                        blockchain,
+                        serviceAgreement.hashFunctionId,
+                        serviceAgreement.scoreFunctionId,
+                        serviceAgreement.keyword,
+                    );
+                }
 
-            try {
+                if (!neighbourhoodEdges && serviceAgreement.scoreFunctionId === 2) {
+                    this.logger.warn(
+                        `Epoch check: unable to find neighbourhood edges for agreement id: ${serviceAgreement.agreementId} for blockchain: ${blockchain}`,
+                    );
+                    continue;
+                }
+
                 const rank = await this.serviceAgreementService.calculateRank(
                     blockchain,
                     serviceAgreement.keyword,

--- a/src/commands/protocols/common/epoch-check/epoch-check-command.js
+++ b/src/commands/protocols/common/epoch-check/epoch-check-command.js
@@ -6,8 +6,6 @@ class EpochCheckCommand extends Command {
         super(ctx);
         this.commandExecutor = ctx.commandExecutor;
         this.blockchainModuleManager = ctx.blockchainModuleManager;
-        this.repositoryModuleManager = ctx.repositoryModuleManager;
-        this.networkModuleManager = ctx.networkModuleManager;
 
         this.errorType = ERROR_TYPE.COMMIT_PROOF.EPOCH_CHECK_ERROR;
     }
@@ -34,17 +32,12 @@ class EpochCheckCommand extends Command {
                     blockchain,
                     operationId,
                 };
-                const peerRecord = await this.repositoryModuleManager.getPeerRecord(
-                    this.networkModuleManager.getPeerId().toB58String(),
-                    blockchain,
-                );
-                if (peerRecord != null) {
-                    return this.commandExecutor.add({
-                        name: 'blockchainEpochCheckCommand',
-                        data: commandData,
-                        period: this.calculateCommandPeriod(),
-                    });
-                }
+
+                return this.commandExecutor.add({
+                    name: 'blockchainEpochCheckCommand',
+                    data: commandData,
+                    period: this.calculateCommandPeriod(),
+                });
             }),
         );
 

--- a/src/commands/protocols/common/epoch-check/epoch-check-command.js
+++ b/src/commands/protocols/common/epoch-check/epoch-check-command.js
@@ -7,6 +7,7 @@ class EpochCheckCommand extends Command {
         this.commandExecutor = ctx.commandExecutor;
         this.blockchainModuleManager = ctx.blockchainModuleManager;
         this.repositoryModuleManager = ctx.repositoryModuleManager;
+        this.networkModuleManager = ctx.networkModuleManager;
 
         this.errorType = ERROR_TYPE.COMMIT_PROOF.EPOCH_CHECK_ERROR;
     }

--- a/src/commands/protocols/common/epoch-check/epoch-check-command.js
+++ b/src/commands/protocols/common/epoch-check/epoch-check-command.js
@@ -6,6 +6,7 @@ class EpochCheckCommand extends Command {
         super(ctx);
         this.commandExecutor = ctx.commandExecutor;
         this.blockchainModuleManager = ctx.blockchainModuleManager;
+        this.repositoryModuleManager = ctx.repositoryModuleManager;
 
         this.errorType = ERROR_TYPE.COMMIT_PROOF.EPOCH_CHECK_ERROR;
     }

--- a/src/commands/protocols/common/epoch-check/epoch-check-command.js
+++ b/src/commands/protocols/common/epoch-check/epoch-check-command.js
@@ -32,11 +32,17 @@ class EpochCheckCommand extends Command {
                     blockchain,
                     operationId,
                 };
-                return this.commandExecutor.add({
-                    name: 'blockchainEpochCheckCommand',
-                    data: commandData,
-                    period: this.calculateCommandPeriod(),
-                });
+                const peerRecord = await this.repositoryModuleManager.getPeerRecord(
+                    this.networkModuleManager.getPeerId().toB58String(),
+                    blockchain,
+                );
+                if (peerRecord != null) {
+                    return this.commandExecutor.add({
+                        name: 'blockchainEpochCheckCommand',
+                        data: commandData,
+                        period: this.calculateCommandPeriod(),
+                    });
+                }
             }),
         );
 


### PR DESCRIPTION
As a node runner, you might want to withdraw stake and then leave the node running so that it can submit proofs for previously submitted commits. The node should not attempt to submit commits though, as it is not included in the sharding table anymore.