### PR TITLE
Add check if service agreement exists and retry mechanism for invalid data in getAgreementData

### DIFF
--- a/src/modules/blockchain/implementation/web3-service.js
+++ b/src/modules/blockchain/implementation/web3-service.js
@@ -1101,57 +1101,41 @@ class Web3Service {
     }
 
     async getAgreementData(agreementId) {
-        const serviceAgreementExists = await this.serviceAgreementExists(agreementId);
-
-        if (serviceAgreementExists) {
-            const maxNumberOfRetries = 3;
-            const retryDelayInSec = 12;
-            let retryCount = 0;
-            while (retryCount < maxNumberOfRetries) {
-                const result = await this.callContractFunction(
-                    this.ServiceAgreementStorageProxyContract,
-                    'getAgreementData',
-                    [agreementId],
-                );
-                const agreementData = {
-                    startTime: result['0'].toNumber(),
-                    epochsNumber: result['1'],
-                    epochLength: result['2'].toNumber(),
-                    tokenAmount: result['3'][0],
-                    updateTokenAmount: result['3'][1],
-                    scoreFunctionId: result['4'][0],
-                    proofWindowOffsetPerc: result['4'][1],
-                };
-                if (
-                    agreementData.startTime === 0 &&
-                    agreementData.epochsNumber === 0 &&
-                    agreementData.epochLength === 0 &&
-                    agreementData.tokenAmount.eq(this.toBigNumber(0)) &&
-                    agreementData.updateTokenAmount.eq(this.toBigNumber(0)) &&
-                    agreementData.scoreFunctionId === 0 &&
-                    agreementData.proofWindowOffsetPerc === 0
-                ) {
-                    retryCount += 1;
-                    await sleep(retryDelayInSec * 1000);
-                } else {
-                    return agreementData;
-                }
+        const maxNumberOfRetries = 3;
+        const retryDelayInSec = 12;
+        let retryCount = 0;
+        while (retryCount < maxNumberOfRetries) {
+            const result = await this.callContractFunction(
+                this.ServiceAgreementStorageProxyContract,
+                'getAgreementData',
+                [agreementId],
+            );
+            const agreementData = {
+                startTime: result['0'].toNumber(),
+                epochsNumber: result['1'],
+                epochLength: result['2'].toNumber(),
+                tokenAmount: result['3'][0],
+                updateTokenAmount: result['3'][1],
+                scoreFunctionId: result['4'][0],
+                proofWindowOffsetPerc: result['4'][1],
+            };
+            if (
+                agreementData.startTime === 0 &&
+                agreementData.epochsNumber === 0 &&
+                agreementData.epochLength === 0 &&
+                agreementData.tokenAmount.eq(this.toBigNumber(0)) &&
+                agreementData.updateTokenAmount.eq(this.toBigNumber(0)) &&
+                agreementData.scoreFunctionId === 0 &&
+                agreementData.proofWindowOffsetPerc === 0
+            ) {
+                retryCount += 1;
+                await sleep(retryDelayInSec * 1000);
+            } else {
+                return agreementData;
             }
-            throw Error(
-                `Can't get valid agreement data for service agreement id: ${agreementId} doesn't exist on blockchain: ${this.getBlockchainId()}`,
-            );
-        } else {
-            throw Error(
-                `Service agreement with agreement id: ${agreementId} doesn't exist on blockchain: ${this.getBlockchainId()}`,
-            );
         }
-    }
-
-    async serviceAgreementExists(agreementId) {
-        return this.callContractFunction(
-            this.ServiceAgreementStorageProxy,
-            'serviceAgreementExists',
-            [agreementId],
+        throw Error(
+            `Can't get valid agreement data for service agreement id: ${agreementId} doesn't exist on blockchain: ${this.getBlockchainId()}`,
         );
     }
 


### PR DESCRIPTION
# Description

Method getAgreementData sometimes because of RPC error returns all zeros as a response, now response is validated and there is a retry mechanism is the response is invalid.
All zeros are correct response for non-existent agreement id. Check if the agreement with the given id exists is added and implemented.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
