### PR TITLE
fix: wait for asset sync get result

### DIFF
--- a/src/commands/common/asset-sync-command.js
+++ b/src/commands/common/asset-sync-command.js
@@ -245,7 +245,7 @@ class AssetSyncCommand extends Command {
                 let attempt = 0;
                 let getResult;
                 do {
-                    await setTimeout(ASSET_SYNC_PARAMETERS.GET_RESULT_POLLING_INFTERVAL_MILLIS);
+                    await setTimeout(ASSET_SYNC_PARAMETERS.GET_RESULT_POLLING_INTERVAL_MILLIS);
 
                     getResult = await this.operationIdService.getOperationIdRecord(operationId);
                     attempt += 1;


### PR DESCRIPTION
There is a typo preventing asset sync command to properly wait for results, resulting in all get requests being executed at the same time, and the node getting blacklisted on the network.