### PR TITLE
Improvment/use both ip and token auth

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -161,7 +161,8 @@
             "tokenBasedAuthEnabled": false,
             "loggingEnabled": true,
             "ipWhitelist": ["::1", "127.0.0.1"],
-            "publicOperations": []
+            "publicOperations": [],
+            "bothIpAndTokenAuthRequired": false
         }
     },
     "test": {
@@ -314,7 +315,8 @@
             "tokenBasedAuthEnabled": false,
             "loggingEnabled": true,
             "ipWhitelist": ["::1", "127.0.0.1"],
-            "publicOperations": []
+            "publicOperations": [],
+            "bothIpAndTokenAuthRequired": false
         }
     },
     "testnet": {
@@ -480,7 +482,8 @@
             "tokenBasedAuthEnabled": false,
             "loggingEnabled": true,
             "ipWhitelist": ["::1", "127.0.0.1"],
-            "publicOperations": []
+            "publicOperations": [],
+            "bothIpAndTokenAuthRequired": false
         }
     },
     "devnet": {
@@ -646,7 +649,8 @@
             "tokenBasedAuthEnabled": false,
             "loggingEnabled": true,
             "ipWhitelist": ["::1", "127.0.0.1"],
-            "publicOperations": []
+            "publicOperations": [],
+            "bothIpAndTokenAuthRequired": false
         }
     },
     "mainnet": {
@@ -812,6 +816,7 @@
             "tokenBasedAuthEnabled": false,
             "loggingEnabled": true,
             "ipWhitelist": ["::1", "127.0.0.1"],
+            "publicOperations": [],
             "bothIpAndTokenAuthRequired": false
         }
     }

--- a/config/config.json
+++ b/config/config.json
@@ -812,7 +812,7 @@
             "tokenBasedAuthEnabled": false,
             "loggingEnabled": true,
             "ipWhitelist": ["::1", "127.0.0.1"],
-            "bothIpAndTokenAuthEnabled": false
+            "bothIpAndTokenAuthRequired": false
         }
     }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -812,7 +812,7 @@
             "tokenBasedAuthEnabled": false,
             "loggingEnabled": true,
             "ipWhitelist": ["::1", "127.0.0.1"],
-            "publicOperations": []
+            "bothIpAndTokenAuthEnabled": false
         }
     }
 }

--- a/src/service/auth-service.js
+++ b/src/service/auth-service.js
@@ -49,6 +49,20 @@ class AuthService {
             return true;
         }
 
+        /* 
+            If IP is whitelisted and both IP and Token Auth is NOT required pass authorization check.
+            Authentication middleware checks if IP is white listed before authorization middleware.
+        */
+        if (!(await this._isTokenValid(token))) {
+            if (
+                !this._authConfig.bothIpAndTokenAuthRequired &&
+                this._authConfig.ipBasedAuthEnabled
+            ) {
+                return true;
+            }
+            return false;
+        }
+
         const tokenId = jwtUtil.getPayload(token).jti;
         const abilities = await this._repository.getTokenAbilities(tokenId);
 
@@ -89,6 +103,10 @@ class AuthService {
     async _isTokenValid(token) {
         if (!this._authConfig.tokenBasedAuthEnabled) {
             return true;
+        }
+
+        if (!token) {
+            return false;
         }
 
         if (!jwtUtil.validateJWT(token)) {

--- a/src/service/auth-service.js
+++ b/src/service/auth-service.js
@@ -18,7 +18,18 @@ class AuthService {
         const isWhitelisted = this._isIpWhitelisted(ip);
         const isTokenValid = await this._isTokenValid(token);
 
-        const isAuthenticated = isWhitelisted && isTokenValid;
+        const tokenAuthEnabled = this._authConfig.tokenBasedAuthEnabled;
+        const ipAuthEnabled = this._authConfig.ipBasedAuthEnabled;
+        const requiresBoth = this._authConfig.bothIpAndTokenAuthRequired;
+
+        let isAuthenticated = false;
+        if (tokenAuthEnabled && ipAuthEnabled) {
+            isAuthenticated = requiresBoth
+                ? isWhitelisted && isTokenValid
+                : isWhitelisted || isTokenValid;
+        } else {
+            isAuthenticated = isWhitelisted && isTokenValid;
+        }
 
         if (!isAuthenticated) {
             this._logMessage('Received unauthenticated request.');


### PR DESCRIPTION
# Description

If both ip and token authentication are enabled, it was required that both passes, with these changes in config it can be enabled if both or just one need to pass authentication.


## Type of change


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added changed to one devnetnode, and tried to send info request with combitions of all authentication option enabled or disabled

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
