### PR TITLE
Set proximityScoreFunctionsPairId in bid suggestion schema to accept only 2

### DIFF
--- a/src/controllers/http-api/v0/request-schema/bid-suggestion-schema-v0.js
+++ b/src/controllers/http-api/v0/request-schema/bid-suggestion-schema-v0.js
@@ -39,7 +39,8 @@ export default (argumentsObject) => ({
         },
         proximityScoreFunctionsPairId: {
             type: 'number',
-            const: 2,
+            minimum: 2,
+            maximum: 2,
         },
         bidSuggestionRange: {
             type: 'string',

--- a/src/controllers/http-api/v0/request-schema/bid-suggestion-schema-v0.js
+++ b/src/controllers/http-api/v0/request-schema/bid-suggestion-schema-v0.js
@@ -39,8 +39,7 @@ export default (argumentsObject) => ({
         },
         proximityScoreFunctionsPairId: {
             type: 'number',
-            minimum: 1,
-            maximum: 2,
+            const: 2,
         },
         bidSuggestionRange: {
             type: 'string',


### PR DESCRIPTION

# Description

Limit getBidSuggetsion endpoint only to accept 2 as proximityScoreFunctionsPairId value.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
