### PR TITLE
Increase default connection pool number

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -77,7 +77,14 @@
                             "port": "3306",
                             "host": "localhost",
                             "dialect": "mysql",
-                            "logging": false
+                            "logging": false,
+                            "pool": {
+                                "max": 120,
+                                "min": 0,
+                                "acquire": 60000,
+                                "idle": 10000,
+                                "evict": 1000
+                            }
                         }
                     }
                 }
@@ -260,7 +267,14 @@
                             "port": "3306",
                             "host": "localhost",
                             "dialect": "mysql",
-                            "logging": false
+                            "logging": false,
+                            "pool": {
+                                "max": 120,
+                                "min": 0,
+                                "acquire": 60000,
+                                "idle": 10000,
+                                "evict": 1000
+                            }
                         }
                     }
                 }
@@ -413,7 +427,14 @@
                             "port": "3306",
                             "host": "localhost",
                             "dialect": "mysql",
-                            "logging": false
+                            "logging": false,
+                            "pool": {
+                                "max": 120,
+                                "min": 0,
+                                "acquire": 60000,
+                                "idle": 10000,
+                                "evict": 1000
+                            }
                         }
                     }
                 }
@@ -597,7 +618,14 @@
                             "port": "3306",
                             "host": "localhost",
                             "dialect": "mysql",
-                            "logging": false
+                            "logging": false,
+                            "pool": {
+                                "max": 120,
+                                "min": 0,
+                                "acquire": 60000,
+                                "idle": 10000,
+                                "evict": 1000
+                            }
                         }
                     }
                 }
@@ -781,7 +809,14 @@
                             "port": "3306",
                             "host": "localhost",
                             "dialect": "mysql",
-                            "logging": false
+                            "logging": false,
+                            "pool": {
+                                "max": 120,
+                                "min": 0,
+                                "acquire": 60000,
+                                "idle": 10000,
+                                "evict": 1000
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
# Description
An increased number of connection node can have at the same time with MySQL server.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
It was set on some mainnet nodes, and showed improvement

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
