### PR TITLE
Rework KC insert to insert in KA chunks

### DIFF
--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -270,23 +270,47 @@ class OtTripleStore {
         return this.ask(repository, query);
     }
 
-    async createKnowledgeCollectionNamedGraphs(repository, uals, assetsNQuads, visibility) {
-        const query = `
-            PREFIX schema: <${SCHEMA_CONTEXT}>
-            INSERT DATA {
-                ${uals
-                    .map(
-                        (ual, index) => `
+    async createKnowledgeCollectionNamedGraphs(
+        repository,
+        uals,
+        assetsNQuads,
+        visibility,
+        retries = 5,
+        retryDelay = 10,
+    ) {
+        const queries = uals.map(
+            (ual, index) => `
+                PREFIX schema: <${SCHEMA_CONTEXT}>
+                INSERT DATA {
                     GRAPH <${ual}/${visibility}> {
                         ${assetsNQuads[index].join('\n')}
                     }
-                `,
-                    )
-                    .join('\n')}
-            }
-        `;
+                }
+            `,
+        );
+        for (const [index, query] of queries.entries()) {
+            let attempts = 0;
+            let success = false;
 
-        await this.queryVoid(repository, query);
+            while (attempts < retries && !success) {
+                try {
+                    await this.queryVoid(repository, query);
+                    success = true;
+                } catch (error) {
+                    attempts += 1;
+                    if (attempts < retries) {
+                        this.logger.warn(
+                            `Insert failed for GRAPH <${uals[index]}/${visibility}>. Attempt ${attempts}/${retries}. Retrying in ${retryDelay}ms.`,
+                        );
+                        await setTimeout(retryDelay);
+                    } else {
+                        throw new Error(
+                            `Failed to insert into GRAPH <${uals[index]}/${visibility}> after ${retries} attempts.`,
+                        );
+                    }
+                }
+            }
+        }
     }
 
     async deleteKnowledgeCollectionNamedGraphs(repository, uals) {

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -38,7 +38,7 @@ class TripleStoreService {
         knowledgeCollectionUAL,
         triples,
         retries = 5,
-        retryDelay = 0,
+        retryDelay = 50,
     ) {
         this.logger.info(
             `Inserting Knowledge Collection with the UAL: ${knowledgeCollectionUAL} ` +


### PR DESCRIPTION
# Description

Breaks insert into multiple transaction from one atomic. Each KA named graph is inserted separately. 
Add retries that are done if one KA insert fails and only for that KA instead of for the whole collection. 

Fixes # (issue)

Should tackle #3669 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue))


# How Has This Been Tested?

Testedon local network with multiple publishes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
