### PR TITLE
Fix triple-store socket hangup issue

### DIFF
--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -1,5 +1,6 @@
 import { QueryEngine as Engine } from '@comunica/query-sparql';
 import { setTimeout } from 'timers/promises';
+import axios from 'axios';
 import {
     SCHEMA_CONTEXT,
     TRIPLE_STORE_CONNECT_MAX_RETRIES,
@@ -565,7 +566,11 @@ class OtTripleStore {
     }
 
     async queryVoid(repository, query) {
-        return this.queryEngine.queryVoid(query, this.repositories[repository].updateContext);
+        await axios.post(this.repositories[repository].sparqlEndpointUpdate, query, {
+            headers: {
+                'Content-Type': 'application/sparql-update',
+            },
+        });
     }
 
     async ask(repository, query) {


### PR DESCRIPTION
# Description

Fix triple store socket hangup issue by replacing communica with axios

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Implemented this logic on testnet nodes 1 and 2 and monitored loggly for "Failed to store Knowledge Collection with the UAL" logs. Since the logic was implemented (10.2. ~17h CET), there has been no occurrence of this error in loggly for respective nodes. Insert logs are present.
- [ ] Implemented this logic on testnet node 1 (11.2. ~9h CET) which previously had failed storage attempts roughly every 1h. Since the logic was implemented, there has been no occurrence of this error in loggly for this node. Insert logs are present.
