### PR TITLE
Fixed rollback mechanism to delete already inserted named graph is whole insert fails

### DIFF
--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -316,11 +316,13 @@ class OtTripleStore {
         return createdGraphs;
     }
 
-    async deleteKnowledgeCollectionNamedGraphs(repository, namedGraphs) {
+    async deleteKnowledgeCollectionNamedGraphs(repository, namedGraphs, knowledgeCollectionUAL) {
         if (!namedGraphs || namedGraphs.length === 0) return;
 
         const query = `${namedGraphs.map((graph) => `DROP GRAPH <${graph}>`).join(';\n')};`;
 
+        // await this.deleteKnowledgeCollectionMetadata(repository, knowledgeCollectionUAL);
+        console.log(knowledgeCollectionUAL);
         await this.queryVoid(repository, query);
     }
 
@@ -462,16 +464,28 @@ class OtTripleStore {
     }
 
     async deleteKnowledgeCollectionMetadata(repository, ual) {
+        // const query = `
+        //     DELETE
+        //     WHERE {
+        //         GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
+        //             ?ual ?p ?o .
+        //             FILTER(STRSTARTS(STR(?ual), "${ual}/"))
+        //         }
+        //     }
+        // `;
         const query = `
-            DELETE
-            WHERE {
-                GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
-                    ?ual ?p ?o .
-                    FILTER(STRSTARTS(STR(?ual), "${ual}/"))
-                }
+        DELETE {
+            GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
+                ?ual ?p ?o .
             }
-        `;
-
+        }
+        WHERE {
+            GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
+                ?ual ?p ?o .
+                FILTER(STRSTARTS(STR(?ual), "${ual}/"))
+            }
+        }`;
+        console.log('delete query', query);
         await this.queryVoid(repository, query);
     }
 
@@ -570,6 +584,7 @@ class OtTripleStore {
     }
 
     async queryVoid(repository, query) {
+        console.log('Update Endpoint:', this.repositories[repository].updateContext);
         return this.queryEngine.queryVoid(query, this.repositories[repository].updateContext);
     }
 

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -461,19 +461,13 @@ class OtTripleStore {
         await this.queryVoid(repository, query);
     }
 
-    async deleteKnowledgeCollectionMetadata(repository, ual) {
-        const query = `
-        DELETE {
-            GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
-                ?ual ?p ?o .
-            }
-        }
-        WHERE {
-            GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
-                ?ual ?p ?o .
-                FILTER(STRSTARTS(STR(?ual), "${ual}/"))
-            }
-        }`;
+    async deleteKnowledgeCollectionMetadata(repository, uals) {
+        const cleanedUals = [...new Set(uals.map((ual) => ual.replace(/\/(public|private)$/, '')))];
+
+        const query = `${cleanedUals
+            .map((ual) => `DELETE WHERE { <${ual}> ?p ?o . }`)
+            .join(';\n')};`;
+
         await this.queryVoid(repository, query);
     }
 

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -316,13 +316,11 @@ class OtTripleStore {
         return createdGraphs;
     }
 
-    async deleteKnowledgeCollectionNamedGraphs(repository, namedGraphs, knowledgeCollectionUAL) {
+    async deleteKnowledgeCollectionNamedGraphs(repository, namedGraphs) {
         if (!namedGraphs || namedGraphs.length === 0) return;
 
         const query = `${namedGraphs.map((graph) => `DROP GRAPH <${graph}>`).join(';\n')};`;
 
-        // await this.deleteKnowledgeCollectionMetadata(repository, knowledgeCollectionUAL);
-        console.log(knowledgeCollectionUAL);
         await this.queryVoid(repository, query);
     }
 
@@ -464,15 +462,6 @@ class OtTripleStore {
     }
 
     async deleteKnowledgeCollectionMetadata(repository, ual) {
-        // const query = `
-        //     DELETE
-        //     WHERE {
-        //         GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
-        //             ?ual ?p ?o .
-        //             FILTER(STRSTARTS(STR(?ual), "${ual}/"))
-        //         }
-        //     }
-        // `;
         const query = `
         DELETE {
             GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
@@ -485,7 +474,6 @@ class OtTripleStore {
                 FILTER(STRSTARTS(STR(?ual), "${ual}/"))
             }
         }`;
-        console.log('delete query', query);
         await this.queryVoid(repository, query);
     }
 
@@ -584,7 +572,6 @@ class OtTripleStore {
     }
 
     async queryVoid(repository, query) {
-        console.log('Update Endpoint:', this.repositories[repository].updateContext);
         return this.queryEngine.queryVoid(query, this.repositories[repository].updateContext);
     }
 

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -278,7 +278,6 @@ class OtTripleStore {
         retries = 5,
         retryDelay = 10,
     ) {
-        const createdGraphs = [];
         const queries = uals.map(
             (ual, index) => `
                 PREFIX schema: <${SCHEMA_CONTEXT}>
@@ -297,7 +296,6 @@ class OtTripleStore {
                 try {
                     await this.queryVoid(repository, query);
                     success = true;
-                    createdGraphs.push(`${uals[index]}/${visibility}`);
                 } catch (error) {
                     attempts += 1;
                     if (attempts <= retries) {
@@ -313,7 +311,6 @@ class OtTripleStore {
                 }
             }
         }
-        return createdGraphs;
     }
 
     async deleteKnowledgeCollectionNamedGraphs(repository, namedGraphs) {

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -278,6 +278,7 @@ class OtTripleStore {
         retries = 5,
         retryDelay = 10,
     ) {
+        const createdGraphs = [];
         const queries = uals.map(
             (ual, index) => `
                 PREFIX schema: <${SCHEMA_CONTEXT}>
@@ -296,6 +297,7 @@ class OtTripleStore {
                 try {
                     await this.queryVoid(repository, query);
                     success = true;
+                    createdGraphs.push(`${uals[index]}/${visibility}`);
                 } catch (error) {
                     attempts += 1;
                     if (attempts <= retries) {
@@ -311,10 +313,13 @@ class OtTripleStore {
                 }
             }
         }
+        return createdGraphs;
     }
 
-    async deleteKnowledgeCollectionNamedGraphs(repository, uals) {
-        const query = `${uals.map((ual) => `DROP GRAPH <${ual}>`).join(';\n')};`;
+    async deleteKnowledgeCollectionNamedGraphs(repository, namedGraphs) {
+        if (!namedGraphs || namedGraphs.length === 0) return;
+
+        const query = `${namedGraphs.map((graph) => `DROP GRAPH <${graph}>`).join(';\n')};`;
 
         await this.queryVoid(repository, query);
     }

--- a/src/modules/triple-store/triple-store-module-manager.js
+++ b/src/modules/triple-store/triple-store-module-manager.js
@@ -129,20 +129,11 @@ class TripleStoreModuleManager extends BaseModuleManager {
         }
     }
 
-    async deleteKnowledgeCollectionNamedGraphs(
-        implementationName,
-        repository,
-        nampedGraphs,
-        knowledgeCollectionUAL,
-    ) {
+    async deleteKnowledgeCollectionNamedGraphs(implementationName, repository, namedGraphs) {
         if (this.getImplementation(implementationName)) {
             return this.getImplementation(
                 implementationName,
-            ).module.deleteKnowledgeCollectionNamedGraphs(
-                repository,
-                nampedGraphs,
-                knowledgeCollectionUAL,
-            );
+            ).module.deleteKnowledgeCollectionNamedGraphs(repository, namedGraphs);
         }
     }
 

--- a/src/modules/triple-store/triple-store-module-manager.js
+++ b/src/modules/triple-store/triple-store-module-manager.js
@@ -129,11 +129,20 @@ class TripleStoreModuleManager extends BaseModuleManager {
         }
     }
 
-    async deleteKnowledgeCollectionNamedGraphs(implementationName, repository, uals) {
+    async deleteKnowledgeCollectionNamedGraphs(
+        implementationName,
+        repository,
+        nampedGraphs,
+        knowledgeCollectionUAL,
+    ) {
         if (this.getImplementation(implementationName)) {
             return this.getImplementation(
                 implementationName,
-            ).module.deleteKnowledgeCollectionNamedGraphs(repository, uals);
+            ).module.deleteKnowledgeCollectionNamedGraphs(
+                repository,
+                nampedGraphs,
+                knowledgeCollectionUAL,
+            );
         }
     }
 

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -84,17 +84,22 @@ class TripleStoreService {
             (_, index) => `${knowledgeCollectionUAL}/${index + 1}`,
         );
 
+        const createdNamedGraphs = [];
+
         if (!existsInNamedGraphs) {
             promises.push(
-                this.tripleStoreModuleManager.createKnowledgeCollectionNamedGraphs(
-                    this.repositoryImplementations[repository],
-                    repository,
-                    publicKnowledgeAssetsUALs,
-                    publicKnowledgeAssetsTriplesGrouped,
-                    TRIPLES_VISIBILITY.PUBLIC,
-                ),
+                this.tripleStoreModuleManager
+                    .createKnowledgeCollectionNamedGraphs(
+                        this.repositoryImplementations[repository],
+                        repository,
+                        publicKnowledgeAssetsUALs,
+                        publicKnowledgeAssetsTriplesGrouped,
+                        TRIPLES_VISIBILITY.PUBLIC,
+                    )
+                    .then((createdGraphs) => {
+                        createdNamedGraphs.push(...createdGraphs);
+                    }),
             );
-
             if (triples.private?.length) {
                 const privateKnowledgeAssetsTriplesGrouped = kcTools.groupNquadsBySubject(
                     triples.private,
@@ -128,13 +133,17 @@ class TripleStoreService {
                     }
                 }
                 promises.push(
-                    this.tripleStoreModuleManager.createKnowledgeCollectionNamedGraphs(
-                        this.repositoryImplementations[repository],
-                        repository,
-                        privateKnowledgeAssetsUALs,
-                        privateKnowledgeAssetsTriplesGrouped,
-                        TRIPLES_VISIBILITY.PRIVATE,
-                    ),
+                    this.tripleStoreModuleManager
+                        .createKnowledgeCollectionNamedGraphs(
+                            this.repositoryImplementations[repository],
+                            repository,
+                            privateKnowledgeAssetsUALs,
+                            privateKnowledgeAssetsTriplesGrouped,
+                            TRIPLES_VISIBILITY.PRIVATE,
+                        )
+                        .then((createdGraphs) => {
+                            createdNamedGraphs.push(...createdGraphs);
+                        }),
                 );
             }
         }
@@ -155,11 +164,9 @@ class TripleStoreService {
 
         let attempts = 0;
         let success = false;
-
         while (attempts < retries && !success) {
             try {
                 await Promise.all(promises);
-
                 success = true;
 
                 this.logger.info(
@@ -187,15 +194,16 @@ class TripleStoreService {
                             `to the Triple Store's ${repository} repository. Rolling back data.`,
                     );
 
-                    if (!existsInNamedGraphs) {
+                    if (!existsInNamedGraphs && createdNamedGraphs.length > 0) {
                         this.logger.info(
                             `Rolling back Knowledge Collection with the UAL: ${knowledgeCollectionUAL} ` +
                                 `from the Triple Store's ${repository} repository Named Graphs.`,
                         );
+                        this.logger.info(`Named Graphs being deleted: ${createdNamedGraphs} `);
                         await this.tripleStoreModuleManager.deleteKnowledgeCollectionNamedGraphs(
                             this.repositoryImplementations[repository],
                             repository,
-                            publicKnowledgeAssetsUALs,
+                            createdNamedGraphs,
                         );
                     }
 

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -85,7 +85,7 @@ class TripleStoreService {
         );
 
         const allPossibleNamedGraphs = [];
-        const createdUALs = [];
+
         if (!existsInNamedGraphs) {
             promises.push(
                 this.tripleStoreModuleManager.createKnowledgeCollectionNamedGraphs(
@@ -98,7 +98,7 @@ class TripleStoreService {
             );
 
             allPossibleNamedGraphs.push(...publicKnowledgeAssetsUALs.map((ual) => `${ual}/public`));
-            createdUALs.push(publicKnowledgeAssetsUALs);
+
             if (triples.private?.length) {
                 const privateKnowledgeAssetsTriplesGrouped = kcTools.groupNquadsBySubject(
                     triples.private,
@@ -145,7 +145,6 @@ class TripleStoreService {
                 allPossibleNamedGraphs.push(
                     ...privateKnowledgeAssetsUALs.map((ual) => `${ual}/private`),
                 );
-                createdUALs.push(privateKnowledgeAssetsUALs);
             }
         }
 
@@ -202,22 +201,19 @@ class TripleStoreService {
                             `Rolling back Knowledge Collection with the UAL: ${knowledgeCollectionUAL} ` +
                                 `from the Triple Store's ${repository} repository Named Graphs.`,
                         );
-                        this.logger.info(
-                            `Deleting knowledge collection named graphs for rolledback collection`,
-                        );
-                        await this.tripleStoreModuleManager.deleteKnowledgeCollectionNamedGraphs(
-                            this.repositoryImplementations[repository],
-                            repository,
-                            allPossibleNamedGraphs,
-                            knowledgeCollectionUAL,
-                        );
 
-                        this.logger.info(`Deleting metadata triples for rolledback collection`);
-                        await this.tripleStoreModuleManager.deleteKnowledgeCollectionMetadata(
-                            this.repositoryImplementations[repository],
-                            repository,
-                            knowledgeCollectionUAL,
-                        );
+                        await Promise.all([
+                            this.tripleStoreModuleManager.deleteKnowledgeCollectionNamedGraphs(
+                                this.repositoryImplementations[repository],
+                                repository,
+                                allPossibleNamedGraphs,
+                            ),
+                            this.tripleStoreModuleManager.deleteKnowledgeCollectionMetadata(
+                                this.repositoryImplementations[repository],
+                                repository,
+                                allPossibleNamedGraphs,
+                            ),
+                        ]);
                     }
 
                     throw new Error(

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -84,22 +84,21 @@ class TripleStoreService {
             (_, index) => `${knowledgeCollectionUAL}/${index + 1}`,
         );
 
-        const createdNamedGraphs = [];
-
+        const allPossibleNamedGraphs = [];
+        const createdUALs = [];
         if (!existsInNamedGraphs) {
             promises.push(
-                this.tripleStoreModuleManager
-                    .createKnowledgeCollectionNamedGraphs(
-                        this.repositoryImplementations[repository],
-                        repository,
-                        publicKnowledgeAssetsUALs,
-                        publicKnowledgeAssetsTriplesGrouped,
-                        TRIPLES_VISIBILITY.PUBLIC,
-                    )
-                    .then((createdGraphs) => {
-                        createdNamedGraphs.push(...createdGraphs);
-                    }),
+                this.tripleStoreModuleManager.createKnowledgeCollectionNamedGraphs(
+                    this.repositoryImplementations[repository],
+                    repository,
+                    publicKnowledgeAssetsUALs,
+                    publicKnowledgeAssetsTriplesGrouped,
+                    TRIPLES_VISIBILITY.PUBLIC,
+                ),
             );
+
+            allPossibleNamedGraphs.push(...publicKnowledgeAssetsUALs.map((ual) => `${ual}/public`));
+            createdUALs.push(publicKnowledgeAssetsUALs);
             if (triples.private?.length) {
                 const privateKnowledgeAssetsTriplesGrouped = kcTools.groupNquadsBySubject(
                     triples.private,
@@ -132,21 +131,24 @@ class TripleStoreService {
                         }
                     }
                 }
+
                 promises.push(
-                    this.tripleStoreModuleManager
-                        .createKnowledgeCollectionNamedGraphs(
-                            this.repositoryImplementations[repository],
-                            repository,
-                            privateKnowledgeAssetsUALs,
-                            privateKnowledgeAssetsTriplesGrouped,
-                            TRIPLES_VISIBILITY.PRIVATE,
-                        )
-                        .then((createdGraphs) => {
-                            createdNamedGraphs.push(...createdGraphs);
-                        }),
+                    this.tripleStoreModuleManager.createKnowledgeCollectionNamedGraphs(
+                        this.repositoryImplementations[repository],
+                        repository,
+                        privateKnowledgeAssetsUALs,
+                        privateKnowledgeAssetsTriplesGrouped,
+                        TRIPLES_VISIBILITY.PRIVATE,
+                    ),
                 );
+
+                allPossibleNamedGraphs.push(
+                    ...privateKnowledgeAssetsUALs.map((ual) => `${ual}/private`),
+                );
+                createdUALs.push(privateKnowledgeAssetsUALs);
             }
         }
+
         const metadataTriples = publicKnowledgeAssetsUALs
             .map(
                 (publicKnowledgeAssetUAL) =>
@@ -164,6 +166,12 @@ class TripleStoreService {
 
         let attempts = 0;
         let success = false;
+        promises.push(
+            new Promise((_, reject) => {
+                reject(new Error('Intentional Failure for Rollback Test'));
+            }),
+        );
+
         while (attempts < retries && !success) {
             try {
                 await Promise.all(promises);
@@ -194,16 +202,18 @@ class TripleStoreService {
                             `to the Triple Store's ${repository} repository. Rolling back data.`,
                     );
 
-                    if (!existsInNamedGraphs && createdNamedGraphs.length > 0) {
+                    if (!existsInNamedGraphs) {
                         this.logger.info(
                             `Rolling back Knowledge Collection with the UAL: ${knowledgeCollectionUAL} ` +
-                                `from the Triple Store's ${repository} repository Named Graphs.`,
+                                `from the Triple Store's ${repository} repository Named Graphs.` +
+                                `Named Graphs being deleted: ${allPossibleNamedGraphs} `,
                         );
-                        this.logger.info(`Named Graphs being deleted: ${createdNamedGraphs} `);
+
                         await this.tripleStoreModuleManager.deleteKnowledgeCollectionNamedGraphs(
                             this.repositoryImplementations[repository],
                             repository,
-                            createdNamedGraphs,
+                            allPossibleNamedGraphs,
+                            knowledgeCollectionUAL,
                         );
                     }
 

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -166,11 +166,6 @@ class TripleStoreService {
 
         let attempts = 0;
         let success = false;
-        promises.push(
-            new Promise((_, reject) => {
-                reject(new Error('Intentional Failure for Rollback Test'));
-            }),
-        );
 
         while (attempts < retries && !success) {
             try {
@@ -205,14 +200,22 @@ class TripleStoreService {
                     if (!existsInNamedGraphs) {
                         this.logger.info(
                             `Rolling back Knowledge Collection with the UAL: ${knowledgeCollectionUAL} ` +
-                                `from the Triple Store's ${repository} repository Named Graphs.` +
-                                `Named Graphs being deleted: ${allPossibleNamedGraphs} `,
+                                `from the Triple Store's ${repository} repository Named Graphs.`,
                         );
-
+                        this.logger.info(
+                            `Deleting knowledge collection named graphs for rolledback collection`,
+                        );
                         await this.tripleStoreModuleManager.deleteKnowledgeCollectionNamedGraphs(
                             this.repositoryImplementations[repository],
                             repository,
                             allPossibleNamedGraphs,
+                            knowledgeCollectionUAL,
+                        );
+
+                        this.logger.info(`Deleting metadata triples for rolledback collection`);
+                        await this.tripleStoreModuleManager.deleteKnowledgeCollectionMetadata(
+                            this.repositoryImplementations[repository],
+                            repository,
                             knowledgeCollectionUAL,
                         );
                     }


### PR DESCRIPTION
# Description

Previously the function that would delete named graphs in case of rollback would delete graphs that didn't exist <UAL>, where it should be <UAL/(public/private)>.Now all created graph names are stored in a list that is passed to the delete function

Fixes # (issue)

Bug fix (non-breaking change which fixes an issue)



