### PR TITLE
Changed the utfConverter function

### DIFF
--- a/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
+++ b/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
@@ -62,7 +62,7 @@ class OtBlazegraph extends OtTripleStore {
     }
 
     utfConverter(input) {
-        return Buffer.from(input, 'binary').toString('utf8');
+        return Buffer.from(input, 'utf8').toString();
     }
 
     async _executeQuery(repository, query, mediaType) {


### PR DESCRIPTION
# Description

utfConverter function was converting some character to unreadable ASCII character which couldn't be parsed with JSON.parse(). 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

