### PR TITLE
Added aditional metadata triples during publish, added an operationalD…

### DIFF
--- a/src/commands/protocols/publish/publish-finalization-command.js
+++ b/src/commands/protocols/publish/publish-finalization-command.js
@@ -70,15 +70,13 @@ class PublishFinalizationCommand extends Command {
                 OPERATION_ID_STATUS.PUBLISH_FINALIZATION.PUBLISH_FINALIZATION_STORE_ASSERTION_START,
             );
 
-            await this.tripleStoreService.insertKnowledgeCollection(
+            const totalTriples = await this.tripleStoreService.insertKnowledgeCollection(
                 TRIPLE_STORE_REPOSITORIES.DKG,
                 ual,
                 assertion,
             );
 
-            const totalTriples =
-                (assertion?.public?.length ?? 0) + (assertion?.private?.length ?? 0);
-            await this.repositoryModuleManager.incrementInsertedTriples(totalTriples);
+            await this.repositoryModuleManager.incrementInsertedTriples(totalTriples ?? 0);
             this.logger.info(`Number of triples added to the database +${totalTriples}`);
 
             await this.operationIdService.updateOperationIdStatus(

--- a/src/commands/protocols/publish/publish-finalization-command.js
+++ b/src/commands/protocols/publish/publish-finalization-command.js
@@ -76,6 +76,11 @@ class PublishFinalizationCommand extends Command {
                 assertion,
             );
 
+            const totalTriples =
+                (assertion?.public?.length ?? 0) + (assertion?.private?.length ?? 0);
+            await this.repositoryModuleManager.incrementInsertedTriples(totalTriples);
+            this.logger.info(`Number of triples added to the database +${totalTriples}`);
+
             await this.operationIdService.updateOperationIdStatus(
                 operationId,
                 blockchain,

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -261,9 +261,9 @@ export const TRANSACTION_PRIORITY = {
 export const V0_PRIVATE_ASSERTION_PREDICATE =
     'https://ontology.origintrail.io/dkg/1.0#privateAssertionID';
 
-export const DKG_CONTAINS_PREDICATE = 'https://ontology.origintrail.io/dkg/1.0#hasNamedGraph';
-
-export const DKG_HAS_KA_PREDICATE = 'https://ontology.origintrail.io/dkg/1.0#hasKnowledgeAsset';
+export const DKG_PREDICATE = 'https://ontology.origintrail.io/dkg/1.0#';
+export const HAS_NAMED_GRAPH_SUFFIX = 'hasNamedGraph';
+export const HAS_KNOWLEDGE_ASSET_SUFFIX = 'hasKnowledgeAsset';
 
 const require = createRequire(import.meta.url);
 

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -150,6 +150,7 @@ export const BASE_NAMED_GRAPHS = {
     UNIFIED: 'unified:graph',
     HISTORICAL_UNIFIED: 'historical-unified:graph',
     METADATA: 'metadata:graph',
+    CURRENT: 'current:graph',
 };
 
 export const REQUIRED_MODULES = [
@@ -259,6 +260,10 @@ export const TRANSACTION_PRIORITY = {
 
 export const V0_PRIVATE_ASSERTION_PREDICATE =
     'https://ontology.origintrail.io/dkg/1.0#privateAssertionID';
+
+export const DKG_CONTAINS_PREDICATE = 'https://ontology.origintrail.io/dkg/1.0#hasNamedGraph';
+
+export const DKG_HAS_KA_PREDICATE = 'https://ontology.origintrail.io/dkg/1.0#hasKnowledgeAsset';
 
 const require = createRequire(import.meta.url);
 

--- a/src/modules/repository/implementation/sequelize/migrations/20250408164300-create-triples-inserted-count-table.js
+++ b/src/modules/repository/implementation/sequelize/migrations/20250408164300-create-triples-inserted-count-table.js
@@ -1,0 +1,18 @@
+export async function up({ context: { queryInterface, Sequelize } }) {
+    await queryInterface.createTable('triples_insert_count', {
+        id: {
+            type: Sequelize.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
+        },
+        count: {
+            type: Sequelize.BIGINT,
+            allowNull: false,
+            defaultValue: 0,
+        },
+    });
+}
+
+export async function down() {
+    // No need to do anything in the down method for truncation
+}

--- a/src/modules/repository/implementation/sequelize/models/triples-inserted-count.js
+++ b/src/modules/repository/implementation/sequelize/models/triples-inserted-count.js
@@ -1,0 +1,23 @@
+export default (sequelize, DataTypes) => {
+    const TriplesInsertCount = sequelize.define(
+        'triples_insert_count',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            count: {
+                type: DataTypes.BIGINT,
+                allowNull: false,
+                defaultValue: 0,
+            },
+        },
+        {
+            timestamps: false,
+            freezeTableName: true,
+        },
+    );
+
+    return TriplesInsertCount;
+};

--- a/src/modules/repository/implementation/sequelize/repositories/inserted-triples-repository.js
+++ b/src/modules/repository/implementation/sequelize/repositories/inserted-triples-repository.js
@@ -11,12 +11,18 @@ class TriplesInsertCountRepository {
     }
 
     async increment(by = 1, options = {}) {
-        await this.model.upsert(
+        const [record] = await this.model.findOrCreate({
+            where: {},
+            defaults: { count: 0 },
+            ...options,
+        });
+
+        await this.model.update(
             {
-                id: 1,
-                count: Sequelize.literal(`COALESCE(count, 0) + ${by}`),
+                count: Sequelize.literal(`count + ${by}`),
             },
             {
+                where: { id: record.id },
                 ...options,
             },
         );

--- a/src/modules/repository/implementation/sequelize/repositories/inserted-triples-repository.js
+++ b/src/modules/repository/implementation/sequelize/repositories/inserted-triples-repository.js
@@ -11,18 +11,12 @@ class TriplesInsertCountRepository {
     }
 
     async increment(by = 1, options = {}) {
-        const [record] = await this.model.findOrCreate({
-            where: {},
-            defaults: { count: 0 },
-            ...options,
-        });
-
-        await this.model.update(
+        await this.model.upsert(
             {
-                count: Sequelize.literal(`count + ${by}`),
+                id: 1,
+                count: Sequelize.literal(`COALESCE(count, 0) + ${by}`),
             },
             {
-                where: { id: record.id },
                 ...options,
             },
         );

--- a/src/modules/repository/implementation/sequelize/repositories/inserted-triples-repository.js
+++ b/src/modules/repository/implementation/sequelize/repositories/inserted-triples-repository.js
@@ -1,0 +1,22 @@
+class TriplesInsertCountRepository {
+    constructor(models) {
+        this.model = models.triples_insert_count;
+    }
+
+    async getCount() {
+        const record = await this.model.findOne();
+        return record?.count || 0;
+    }
+
+    async increment(by = 1) {
+        const [record] = await this.model.findOrCreate({ where: {}, defaults: { count: 0 } });
+        record.count += by;
+        await record.save();
+    }
+
+    async reset() {
+        await this.model.update({ count: 0 }, { where: {} });
+    }
+}
+
+export default TriplesInsertCountRepository;

--- a/src/modules/repository/implementation/sequelize/repositories/inserted-triples-repository.js
+++ b/src/modules/repository/implementation/sequelize/repositories/inserted-triples-repository.js
@@ -1,3 +1,5 @@
+import { Sequelize } from 'sequelize';
+
 class TriplesInsertCountRepository {
     constructor(models) {
         this.model = models.triples_insert_count;
@@ -8,14 +10,22 @@ class TriplesInsertCountRepository {
         return record?.count || 0;
     }
 
-    async increment(by = 1) {
-        const [record] = await this.model.findOrCreate({ where: {}, defaults: { count: 0 } });
-        record.count += by;
-        await record.save();
-    }
+    async increment(by = 1, options = {}) {
+        const [record] = await this.model.findOrCreate({
+            where: {},
+            defaults: { count: 0 },
+            ...options,
+        });
 
-    async reset() {
-        await this.model.update({ count: 0 }, { where: {} });
+        await this.model.update(
+            {
+                count: Sequelize.literal(`count + ${by}`),
+            },
+            {
+                where: { id: record.id },
+                ...options,
+            },
+        );
     }
 }
 

--- a/src/modules/repository/implementation/sequelize/sequelize-repository.js
+++ b/src/modules/repository/implementation/sequelize/sequelize-repository.js
@@ -18,6 +18,7 @@ import TokenRepository from './repositories/token-repository.js';
 import UserRepository from './repositories/user-repository.js';
 // import MissedParanetAssetRepository from './repositories/missed-paranet-asset-repository.js';
 // import ParanetSyncedAssetRepository from './repositories/paranet-synced-asset-repository.js';
+import TriplesInsertCountRepository from './repositories/inserted-triples-repository.js';
 import FinalityStatusRepository from './repositories/finality-status-repository.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -49,6 +50,7 @@ class SequelizeRepository {
             token: new TokenRepository(this.models),
             user: new UserRepository(this.models),
             finality_status: new FinalityStatusRepository(this.models),
+            inserted_triples: new TriplesInsertCountRepository(this.models),
         };
     }
 

--- a/src/modules/repository/repository-module-manager.js
+++ b/src/modules/repository/repository-module-manager.js
@@ -475,6 +475,10 @@ class RepositoryModuleManager extends BaseModuleManager {
             options,
         );
     }
+
+    async incrementInsertedTriples(count) {
+        return this.getRepository('inserted_triples').increment(count);
+    }
 }
 
 export default RepositoryModuleManager;

--- a/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
+++ b/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
@@ -20,17 +20,21 @@ class OtBlazegraph extends OtTripleStore {
             await axios.post(
                 `${url}/blazegraph/namespace`,
                 `com.bigdata.rdf.sail.truthMaintenance=false\n` +
-                    `com.bigdata.namespace.${name}.lex.com.bigdata.btree.BTree.branchingFactor=400\n` +
+                    `com.bigdata.namespace.${name}.spo.com.bigdata.btree.BTree.branchingFactor=1024\n` +
                     `com.bigdata.rdf.store.AbstractTripleStore.textIndex=false\n` +
                     `com.bigdata.rdf.store.AbstractTripleStore.justify=false\n` +
-                    `com.bigdata.namespace.${name}.spo.com.bigdata.btree.BTree.branchingFactor=1024\n` +
                     `com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false\n` +
                     `com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms\n` +
                     `com.bigdata.rdf.sail.namespace=${name}\n` +
                     `com.bigdata.rdf.store.AbstractTripleStore.quads=true\n` +
+                    `com.bigdata.namespace.${name}.lex.com.bigdata.btree.BTree.branchingFactor=400\n` +
                     `com.bigdata.rdf.store.AbstractTripleStore.geoSpatial=false\n` +
                     `com.bigdata.journal.Journal.groupCommit=false\n` +
-                    `com.bigdata.rdf.sail.isolatableIndices=false\n`,
+                    `com.bigdata.rdf.sail.isolatableIndices=false\n` +
+                    `com.bigdata.rdf.store.AbstractTripleStore.enableRawRecordsSupport=false\n` +
+                    `com.bigdata.rdf.store.AbstractTripleStore.Options.inlineTextLiterals=true\n` +
+                    `com.bigdata.rdf.store.AbstractTripleStore.Options.maxInlineTextLength=128\n` +
+                    `com.bigdata.rdf.store.AbstractTripleStore.Options.blobsThreshold=256\n`,
                 {
                     headers: {
                         'Content-Type': 'text/plain',

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -9,6 +9,8 @@ import {
     BASE_NAMED_GRAPHS,
     TRIPLE_ANNOTATION_LABEL_PREDICATE,
     TRIPLES_VISIBILITY,
+    DKG_CONTAINS_PREDICATE,
+    DKG_HAS_KA_PREDICATE,
 } from '../../../constants/constants.js';
 
 class OtTripleStore {
@@ -321,6 +323,44 @@ class OtTripleStore {
                 }
             }
         }
+    }
+
+    async insertIntoCurrentGraph(repository, kaUALs, visibility) {
+        const triples = kaUALs
+            .map((ual) => `<current:graph> <${DKG_CONTAINS_PREDICATE}> <${ual}/${visibility}> .`)
+            .join('\n');
+
+        const query = `
+            INSERT DATA {
+                GRAPH <${BASE_NAMED_GRAPHS.CURRENT}> {
+                    ${triples}
+                }
+            }
+        `;
+
+        await this.queryVoid(repository, query);
+    }
+
+    async insertKCKAConnectionsMetadata(repository, kcUAL, kaUALs, visibility) {
+        const triples = kaUALs
+            .map((ual) => {
+                const graphWithVisibility = `${ual}/${visibility}`;
+                return [
+                    `<${kcUAL}> <${DKG_HAS_KA_PREDICATE}> <${ual}> .`,
+                    `<${kcUAL}> <${DKG_CONTAINS_PREDICATE}> <${graphWithVisibility}> .`,
+                ].join('\n');
+            })
+            .join('\n');
+
+        const query = `
+            INSERT DATA {
+                GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
+                    ${triples}
+                }
+            }
+        `;
+
+        await this.queryVoid(repository, query);
     }
 
     async deleteKnowledgeCollectionNamedGraphs(repository, namedGraphs) {

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -9,8 +9,9 @@ import {
     BASE_NAMED_GRAPHS,
     TRIPLE_ANNOTATION_LABEL_PREDICATE,
     TRIPLES_VISIBILITY,
-    DKG_CONTAINS_PREDICATE,
-    DKG_HAS_KA_PREDICATE,
+    DKG_PREDICATE,
+    HAS_KNOWLEDGE_ASSET_SUFFIX,
+    HAS_NAMED_GRAPH_SUFFIX,
 } from '../../../constants/constants.js';
 
 class OtTripleStore {
@@ -325,9 +326,17 @@ class OtTripleStore {
         }
     }
 
+    async insertMetadataTriples(repository, kcUAL, kaUALs, visibility) {
+        await this.insertIntoCurrentGraph(repository, kaUALs, visibility);
+        await this.insertKCKAConnectionsMetadata(repository, kcUAL, kaUALs, visibility);
+    }
+
     async insertIntoCurrentGraph(repository, kaUALs, visibility) {
         const triples = kaUALs
-            .map((ual) => `<current:graph> <${DKG_CONTAINS_PREDICATE}> <${ual}/${visibility}> .`)
+            .map(
+                (ual) =>
+                    `<current:graph> <${DKG_PREDICATE}${HAS_NAMED_GRAPH_SUFFIX}> <${ual}/${visibility}> .`,
+            )
             .join('\n');
 
         const query = `
@@ -346,8 +355,8 @@ class OtTripleStore {
             .map((ual) => {
                 const graphWithVisibility = `${ual}/${visibility}`;
                 return [
-                    `<${kcUAL}> <${DKG_HAS_KA_PREDICATE}> <${ual}> .`,
-                    `<${kcUAL}> <${DKG_CONTAINS_PREDICATE}> <${graphWithVisibility}> .`,
+                    `<${kcUAL}> <${DKG_PREDICATE}${HAS_KNOWLEDGE_ASSET_SUFFIX}> <${ual}> .`,
+                    `<${kcUAL}> <${DKG_PREDICATE}${HAS_NAMED_GRAPH_SUFFIX}> <${graphWithVisibility}> .`,
                 ].join('\n');
             })
             .join('\n');

--- a/src/modules/triple-store/implementation/ot-triple-store.js
+++ b/src/modules/triple-store/implementation/ot-triple-store.js
@@ -327,31 +327,14 @@ class OtTripleStore {
     }
 
     async insertMetadataTriples(repository, kcUAL, kaUALs, visibility) {
-        await this.insertIntoCurrentGraph(repository, kaUALs, visibility);
-        await this.insertKCKAConnectionsMetadata(repository, kcUAL, kaUALs, visibility);
-    }
-
-    async insertIntoCurrentGraph(repository, kaUALs, visibility) {
-        const triples = kaUALs
+        const currentTriples = kaUALs
             .map(
                 (ual) =>
                     `<current:graph> <${DKG_PREDICATE}${HAS_NAMED_GRAPH_SUFFIX}> <${ual}/${visibility}> .`,
             )
             .join('\n');
 
-        const query = `
-            INSERT DATA {
-                GRAPH <${BASE_NAMED_GRAPHS.CURRENT}> {
-                    ${triples}
-                }
-            }
-        `;
-
-        await this.queryVoid(repository, query);
-    }
-
-    async insertKCKAConnectionsMetadata(repository, kcUAL, kaUALs, visibility) {
-        const triples = kaUALs
+        const connectionTriples = kaUALs
             .map((ual) => {
                 const graphWithVisibility = `${ual}/${visibility}`;
                 return [
@@ -363,8 +346,12 @@ class OtTripleStore {
 
         const query = `
             INSERT DATA {
+                GRAPH <${BASE_NAMED_GRAPHS.CURRENT}> {
+                    ${currentTriples}
+                }
+
                 GRAPH <${BASE_NAMED_GRAPHS.METADATA}> {
-                    ${triples}
+                    ${connectionTriples}
                 }
             }
         `;

--- a/src/modules/triple-store/triple-store-module-manager.js
+++ b/src/modules/triple-store/triple-store-module-manager.js
@@ -129,19 +129,9 @@ class TripleStoreModuleManager extends BaseModuleManager {
         }
     }
 
-    async insertIntoCurrentGraph(implementationName, repository, uals, visibility) {
+    async insertMetadataTriples(implementationName, repository, kcUal, uals, visibility) {
         if (this.getImplementation(implementationName)) {
-            return this.getImplementation(implementationName).module.insertIntoCurrentGraph(
-                repository,
-                uals,
-                visibility,
-            );
-        }
-    }
-
-    async insertKCKAConnectionsMetadata(implementationName, repository, kcUal, uals, visibility) {
-        if (this.getImplementation(implementationName)) {
-            return this.getImplementation(implementationName).module.insertKCKAConnectionsMetadata(
+            return this.getImplementation(implementationName).module.insertMetadataTriples(
                 repository,
                 kcUal,
                 uals,

--- a/src/modules/triple-store/triple-store-module-manager.js
+++ b/src/modules/triple-store/triple-store-module-manager.js
@@ -129,6 +129,27 @@ class TripleStoreModuleManager extends BaseModuleManager {
         }
     }
 
+    async insertIntoCurrentGraph(implementationName, repository, uals, visibility) {
+        if (this.getImplementation(implementationName)) {
+            return this.getImplementation(implementationName).module.insertIntoCurrentGraph(
+                repository,
+                uals,
+                visibility,
+            );
+        }
+    }
+
+    async insertKCKAConnectionsMetadata(implementationName, repository, kcUal, uals, visibility) {
+        if (this.getImplementation(implementationName)) {
+            return this.getImplementation(implementationName).module.insertKCKAConnectionsMetadata(
+                repository,
+                kcUal,
+                uals,
+                visibility,
+            );
+        }
+    }
+
     async deleteKnowledgeCollectionNamedGraphs(implementationName, repository, namedGraphs) {
         if (this.getImplementation(implementationName)) {
             return this.getImplementation(

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -69,8 +69,9 @@ class TripleStoreService {
         const privateHashTriples = [];
         const tripleSet = new Set();
 
-        let totalNumberOfTriplesInserted =
-            (triples?.public?.length ?? 0) + (triples?.private?.length ?? 0);
+        let totalNumberOfTriplesInserted = triples?.public
+            ? triples.public.length + (triples.private?.length ?? 0)
+            : triples?.length ?? 0;
 
         publicAssertion.forEach((triple) => {
             if (triple.startsWith(`<${PRIVATE_HASH_SUBJECT_PREFIX}`)) {

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -114,7 +114,10 @@ class TripleStoreService {
                     TRIPLES_VISIBILITY.PUBLIC,
                 ),
             );
-            totalNumberOfTriplesInserted += publicKnowledgeAssetsUALs.length; // one current metadata triple for each pulibc KA
+            // current metadata triple relates to which named graph that represents Knowledge Asset hold the lates(current) data
+            // so for each Knowledge Asset there will be one current metadata triple
+            // in this case there are publicKnowledgeAssetsUALs.length number of named graphs created so for each there will be one current metadata triple
+            totalNumberOfTriplesInserted += publicKnowledgeAssetsUALs.length;
 
             publicKnowledgeAssetsUALs.forEach((ual) => {
                 const graphWithVisibility = `${ual}/public`;
@@ -184,7 +187,10 @@ class TripleStoreService {
                         TRIPLES_VISIBILITY.PRIVATE,
                     ),
                 );
-                totalNumberOfTriplesInserted += privateKnowledgeAssetsUALs.length; // one current metadata triple for each private KA
+                // current metadata triple relates to which named graph that represents Knowledge Asset hold the lates(current) data
+                // so for each Knowledge Asset there will be one current metadata triple
+                // in this case there are privateKnowledgeAssetsUALs.length number of named graphs created so for each there will be one current metadata triple
+                totalNumberOfTriplesInserted += privateKnowledgeAssetsUALs.length;
 
                 privateKnowledgeAssetsUALs.forEach((ual) => {
                     const graphWithVisibility = `${ual}/private`;

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -7,6 +7,9 @@ import {
     TRIPLE_STORE_REPOSITORY,
     TRIPLES_VISIBILITY,
     PRIVATE_HASH_SUBJECT_PREFIX,
+    DKG_PREDICATE,
+    HAS_KNOWLEDGE_ASSET_SUFFIX,
+    HAS_NAMED_GRAPH_SUFFIX,
 } from '../constants/constants.js';
 
 class TripleStoreService {
@@ -64,6 +67,11 @@ class TripleStoreService {
 
         const filteredPublic = [];
         const privateHashTriples = [];
+        const tripleSet = new Set();
+
+        let totalNumberOfTriplesInserted =
+            (triples?.public?.length ?? 0) + (triples?.private?.length ?? 0);
+
         publicAssertion.forEach((triple) => {
             if (triple.startsWith(`<${PRIVATE_HASH_SUBJECT_PREFIX}`)) {
                 privateHashTriples.push(triple);
@@ -98,17 +106,7 @@ class TripleStoreService {
             );
 
             promises.push(
-                this.tripleStoreModuleManager.insertIntoCurrentGraph(
-                    this.repositoryImplementations[repository],
-                    repository,
-                    publicKnowledgeAssetsUALs,
-                    TRIPLES_VISIBILITY.PUBLIC,
-                ),
-            );
-            this.logger.info(`Adding metadata triples to current graph for public asets`);
-
-            promises.push(
-                this.tripleStoreModuleManager.insertKCKAConnectionsMetadata(
+                this.tripleStoreModuleManager.insertMetadataTriples(
                     this.repositoryImplementations[repository],
                     repository,
                     knowledgeCollectionUAL,
@@ -116,8 +114,21 @@ class TripleStoreService {
                     TRIPLES_VISIBILITY.PUBLIC,
                 ),
             );
+            totalNumberOfTriplesInserted += publicKnowledgeAssetsUALs.length; // one current metadata triple for each pulibc KA
+
+            publicKnowledgeAssetsUALs.forEach((ual) => {
+                const graphWithVisibility = `${ual}/public`;
+
+                tripleSet.add(
+                    `<${knowledgeCollectionUAL}> <${DKG_PREDICATE}${HAS_KNOWLEDGE_ASSET_SUFFIX}> <${ual}> .`,
+                );
+                tripleSet.add(
+                    `<${knowledgeCollectionUAL}> <${DKG_PREDICATE}${HAS_NAMED_GRAPH_SUFFIX}> <${graphWithVisibility}> .`,
+                );
+            });
+
             this.logger.info(
-                `Adding Kc-Ka connections metadata triples to metadata graph for public asets`,
+                `Adding metadata triples for public asets for Knowledge Collection: ${knowledgeCollectionUAL}`,
             );
 
             allPossibleNamedGraphs.push(...publicKnowledgeAssetsUALs.map((ual) => `${ual}/public`));
@@ -164,19 +175,8 @@ class TripleStoreService {
                         TRIPLES_VISIBILITY.PRIVATE,
                     ),
                 );
-
                 promises.push(
-                    this.tripleStoreModuleManager.insertIntoCurrentGraph(
-                        this.repositoryImplementations[repository],
-                        repository,
-                        privateKnowledgeAssetsUALs,
-                        TRIPLES_VISIBILITY.PRIVATE,
-                    ),
-                );
-                this.logger.info(`Adding metadata triples to current graph for private asets`);
-
-                promises.push(
-                    this.tripleStoreModuleManager.insertKCKAConnectionsMetadata(
+                    this.tripleStoreModuleManager.insertMetadataTriples(
                         this.repositoryImplementations[repository],
                         repository,
                         knowledgeCollectionUAL,
@@ -184,8 +184,21 @@ class TripleStoreService {
                         TRIPLES_VISIBILITY.PRIVATE,
                     ),
                 );
+                totalNumberOfTriplesInserted += privateKnowledgeAssetsUALs.length; // one current metadata triple for each private KA
+
+                privateKnowledgeAssetsUALs.forEach((ual) => {
+                    const graphWithVisibility = `${ual}/private`;
+
+                    tripleSet.add(
+                        `<${knowledgeCollectionUAL}> <${DKG_PREDICATE}${HAS_KNOWLEDGE_ASSET_SUFFIX}> <${ual}> .`,
+                    );
+                    tripleSet.add(
+                        `<${knowledgeCollectionUAL}> <${DKG_PREDICATE}${HAS_NAMED_GRAPH_SUFFIX}> <${graphWithVisibility}> .`,
+                    );
+                });
+
                 this.logger.info(
-                    `Adding Kc-Ka connections metadata triples to metadata graph for private asets`,
+                    `Adding metadata triples for private asets for Knowledge Collection: ${knowledgeCollectionUAL}`,
                 );
 
                 allPossibleNamedGraphs.push(
@@ -194,12 +207,14 @@ class TripleStoreService {
             }
         }
 
+        // TODO: add new metadata triples and move to function insertMetadataTriples
         const metadataTriples = publicKnowledgeAssetsUALs
             .map(
                 (publicKnowledgeAssetUAL) =>
                     `<${publicKnowledgeAssetUAL}> <http://schema.org/states> "${publicKnowledgeAssetUAL}:0" .`,
             )
             .join('\n');
+        totalNumberOfTriplesInserted += publicKnowledgeAssetsUALs.length; // one metadata triple for each public KA
 
         promises.push(
             this.tripleStoreModuleManager.insertKnowledgeCollectionMetadata(
@@ -208,6 +223,9 @@ class TripleStoreService {
                 metadataTriples,
             ),
         );
+
+        const uniqueTripleCount = tripleSet.size;
+        totalNumberOfTriplesInserted += uniqueTripleCount;
 
         let attempts = 0;
         let success = false;
@@ -269,6 +287,8 @@ class TripleStoreService {
                 }
             }
         }
+
+        return totalNumberOfTriplesInserted;
     }
 
     async createV6KnowledgeCollection(triplesPublic, ual, triplesPrivate = null) {

--- a/src/service/triple-store-service.js
+++ b/src/service/triple-store-service.js
@@ -97,6 +97,29 @@ class TripleStoreService {
                 ),
             );
 
+            promises.push(
+                this.tripleStoreModuleManager.insertIntoCurrentGraph(
+                    this.repositoryImplementations[repository],
+                    repository,
+                    publicKnowledgeAssetsUALs,
+                    TRIPLES_VISIBILITY.PUBLIC,
+                ),
+            );
+            this.logger.info(`Adding metadata triples to current graph for public asets`);
+
+            promises.push(
+                this.tripleStoreModuleManager.insertKCKAConnectionsMetadata(
+                    this.repositoryImplementations[repository],
+                    repository,
+                    knowledgeCollectionUAL,
+                    publicKnowledgeAssetsUALs,
+                    TRIPLES_VISIBILITY.PUBLIC,
+                ),
+            );
+            this.logger.info(
+                `Adding Kc-Ka connections metadata triples to metadata graph for public asets`,
+            );
+
             allPossibleNamedGraphs.push(...publicKnowledgeAssetsUALs.map((ual) => `${ual}/public`));
 
             if (triples.private?.length) {
@@ -140,6 +163,29 @@ class TripleStoreService {
                         privateKnowledgeAssetsTriplesGrouped,
                         TRIPLES_VISIBILITY.PRIVATE,
                     ),
+                );
+
+                promises.push(
+                    this.tripleStoreModuleManager.insertIntoCurrentGraph(
+                        this.repositoryImplementations[repository],
+                        repository,
+                        privateKnowledgeAssetsUALs,
+                        TRIPLES_VISIBILITY.PRIVATE,
+                    ),
+                );
+                this.logger.info(`Adding metadata triples to current graph for private asets`);
+
+                promises.push(
+                    this.tripleStoreModuleManager.insertKCKAConnectionsMetadata(
+                        this.repositoryImplementations[repository],
+                        repository,
+                        knowledgeCollectionUAL,
+                        privateKnowledgeAssetsUALs,
+                        TRIPLES_VISIBILITY.PRIVATE,
+                    ),
+                );
+                this.logger.info(
+                    `Adding Kc-Ka connections metadata triples to metadata graph for private asets`,
                 );
 
                 allPossibleNamedGraphs.push(


### PR DESCRIPTION
…B table for counting added triples

# Description

In this PR two thing are added:
1. 3 types of metadata triples are inserted upon publish. 2 into metadata graph 1 into current:graph
2. a new table is created in the operationalDB that tables counts the number of triples added upon publish

The triples counter is added for the data migration effort.


- [x] New feature (non-breaking change which adds functionality)
