### PR TITLE
Commands table not being pruned fix

### DIFF
--- a/src/commands/command-executor.js
+++ b/src/commands/command-executor.js
@@ -8,6 +8,7 @@ import {
     DEFAULT_COMMAND_DELAY_IN_MILLS,
     COMMAND_QUEUE_PARALLELISM,
     DEFAULT_COMMAND_PRIORITY,
+    SIX_HOURS_IN_MS,
 } from '../constants/constants.js';
 
 /**
@@ -414,6 +415,9 @@ class CommandExecutor {
         command.priority = command.priority ?? DEFAULT_COMMAND_PRIORITY;
         command.isBlocking = command.isBlocking ?? false;
         command.status = COMMAND_STATUS.PENDING;
+        if (!command.deadlineAt) {
+            command.deadlineAt = command.readyAt + SIX_HOURS_IN_MS;
+        }
 
         if (!command.data) {
             const commandInstance = this.commandResolver.resolve(command.name);
@@ -480,15 +484,16 @@ class CommandExecutor {
                 continue;
             }
 
-            if (!command?.parentId) {
-                continue;
+            if (command?.parentId) {
+                // eslint-disable-next-line no-await-in-loop
+                const parent = await this.repositoryModuleManager.getCommandWithId(
+                    command.parentId,
+                );
+                if (parent && parent.status !== 'COMPLETED') {
+                    continue;
+                }
             }
 
-            // eslint-disable-next-line no-await-in-loop
-            const parent = await this.repositoryModuleManager.getCommandWithId(command.parentId);
-            if (parent && parent.status !== 'COMPLETED') {
-                continue;
-            }
             commands.push(command);
         }
 

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -23,6 +23,8 @@ export const ASK_BATCH_SIZE = 20;
 
 export const RPC_PROVIDER_STALL_TIMEOUT = 60 * 1000;
 
+export const SIX_HOURS_IN_MS = 6 * 60 * 60 * 1000;
+
 export const UINT256_MAX_BN = ethers.constants.MaxUint256;
 
 export const UINT128_MAX_BN = BigNumber.from(2).pow(128).sub(1);


### PR DESCRIPTION
# Description

Added deadline at and removed logic for skipping commands with no parent id



Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

