### PR TITLE
fix message timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "origintrail_node",
-    "version": "8.1.1-rc.5",
+    "version": "8.1.1-rc.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "origintrail_node",
-            "version": "8.1.1-rc.5",
+            "version": "8.1.1-rc.6",
             "license": "ISC",
             "dependencies": {
                 "@comunica/query-sparql": "^4.0.2",
@@ -61,7 +61,6 @@
                 "sequelize": "^6.29.0",
                 "sqlite": "^5.1.1",
                 "sqlite3": "^5.1.7",
-                "timeout-abort-controller": "^3.0.0",
                 "toobusy-js": "^0.5.1",
                 "uint8arrays": "^3.1.0",
                 "umzug": "^3.2.1",
@@ -25308,14 +25307,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/timeout-abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
-            "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
-            "dependencies": {
-                "retimer": "^3.0.0"
-            }
-        },
         "node_modules/tiny-case": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
@@ -47888,14 +47879,6 @@
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
             "dev": true
-        },
-        "timeout-abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
-            "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
-            "requires": {
-                "retimer": "^3.0.0"
-            }
         },
         "tiny-case": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
         "sequelize": "^6.29.0",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
-        "timeout-abort-controller": "^3.0.0",
         "toobusy-js": "^0.5.1",
         "uint8arrays": "^3.1.0",
         "umzug": "^3.2.1",

--- a/src/modules/network/implementation/libp2p-service.js
+++ b/src/modules/network/implementation/libp2p-service.js
@@ -318,7 +318,7 @@ class Libp2pService {
                 `Dialing remotePeerId: ${peerIdString} with public ip: ${publicIp}: protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}`,
             );
 
-            errorMessage = `dial`;
+            errorMessage = `dial peer`;
             operationStart = Date.now();
             const dialPromise = this.node.dialProtocol(peerIdObject, protocol, {
                 signal: timeoutSignal,
@@ -345,7 +345,7 @@ class Libp2pService {
                 `Sending message to ${peerIdString}. protocol: ${protocol}, messageType: ${messageType}, operationId: ${operationId}`,
             );
 
-            errorMessage = `send message`;
+            errorMessage = `send message to peer`;
             operationStart = Date.now();
             await this._sendMessageToStream(stream, streamMessage);
             operationEnd = Date.now();
@@ -353,7 +353,7 @@ class Libp2pService {
                 throw abortError;
             }
 
-            errorMessage = `read response`;
+            errorMessage = `read response from peer`;
             operationStart = Date.now();
             response = await this._readMessageFromStream(
                 stream,
@@ -378,7 +378,7 @@ class Libp2pService {
                 return nackMessage;
             }
         } catch (error) {
-            nackMessage.data.errorMessage = `Unable to ${errorMessage} from peer ${peerIdString}. protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}. Execution time: ${
+            nackMessage.data.errorMessage = `Unable to ${errorMessage} ${peerIdString}. protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}. Execution time: ${
                 (operationEnd ?? Date.now()) - operationStart
             } ms. Error: ${error.message.slice(0, 145)}`;
             return nackMessage;

--- a/src/modules/network/implementation/libp2p-service.js
+++ b/src/modules/network/implementation/libp2p-service.js
@@ -14,7 +14,6 @@ import { InMemoryRateLimiter } from 'rolling-rate-limiter';
 import toobusy from 'toobusy-js';
 import { mkdir, writeFile, readFile, stat } from 'fs/promises';
 import ip from 'ip';
-import { TimeoutController } from 'timeout-abort-controller';
 import {
     NETWORK_API_RATE_LIMIT,
     NETWORK_API_SPAM_DETECTION,
@@ -297,110 +296,95 @@ class Libp2pService {
             .map((addr) => addr.toString().split('/'))
             .filter((splittedAddr) => !ip.isPrivate(splittedAddr[2]))[0]?.[2];
 
-        this.logger.trace(
-            `Dialing remotePeerId: ${peerIdString} with public ip: ${publicIp}: protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}`,
-        );
-        let dialResult;
-        let dialStart;
-        let dialEnd;
-        try {
-            dialStart = Date.now();
-            dialResult = await this.node.dialProtocol(peerIdObject, protocol);
-            dialEnd = Date.now();
-        } catch (error) {
-            dialEnd = Date.now();
-            nackMessage.data.errorMessage = `Unable to dial peer: ${peerIdString}. protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}, dial execution time: ${
-                dialEnd - dialStart
-            } ms. Error: ${error.message}`;
+        const timeoutSignal = AbortSignal.timeout(timeout);
+        const abortError = new Error('Message timed out');
 
-            return nackMessage;
-        }
-        this.logger.trace(
-            `Created stream for peer: ${peerIdString}. protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}, dial execution time: ${
-                dialEnd - dialStart
-            } ms.`,
-        );
-
-        const { stream } = dialResult;
-
-        this.updateSessionStream(operationId, peerIdString, stream);
-
-        const streamMessage = this.createStreamMessage(message, operationId, messageType);
-
-        this.logger.trace(
-            `Sending message to ${peerIdString}. protocol: ${protocol}, messageType: ${messageType}, operationId: ${operationId}`,
-        );
-
-        let sendMessageStart;
-        let sendMessageEnd;
-        try {
-            sendMessageStart = Date.now();
-            await this._sendMessageToStream(stream, streamMessage);
-            sendMessageEnd = Date.now();
-        } catch (error) {
-            sendMessageEnd = Date.now();
-            nackMessage.data.errorMessage = `Unable to send message to peer: ${peerIdString}. protocol: ${protocol}, messageType: ${messageType}, operationId: ${operationId}, execution time: ${
-                sendMessageEnd - sendMessageStart
-            } ms. Error: ${error.message}`;
-
-            return nackMessage;
-        }
-
-        let readResponseStart;
-        let readResponseEnd;
+        const abortPromise = new Promise((_, reject) => {
+            timeoutSignal.onabort = () => reject(abortError);
+        });
+        let stream;
         let response;
-        const abortSignalEventListener = async () => {
-            stream.abort();
+        let errorMessage;
+        let operationStart;
+        let operationEnd;
+        const onAbort = () => {
+            if (stream) stream.abort(abortError);
             response = null;
         };
-        const timeoutController = new TimeoutController(timeout);
+
         try {
-            readResponseStart = Date.now();
+            timeoutSignal.addEventListener('abort', onAbort, { once: true });
+            this.logger.trace(
+                `Dialing remotePeerId: ${peerIdString} with public ip: ${publicIp}: protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}`,
+            );
 
-            timeoutController.signal.addEventListener('abort', abortSignalEventListener, {
-                once: true,
+            errorMessage = `dial`;
+            operationStart = Date.now();
+            const dialPromise = this.node.dialProtocol(peerIdObject, protocol, {
+                signal: timeoutSignal,
             });
+            const dialResult = await Promise.race([dialPromise, abortPromise]);
+            operationEnd = Date.now();
+            if (timeoutSignal.aborted) {
+                throw abortError;
+            }
 
+            this.logger.trace(
+                `Created stream for peer: ${peerIdString}. protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}, dial execution time: ${
+                    operationEnd - operationStart
+                } ms.`,
+            );
+
+            stream = dialResult.stream;
+
+            this.updateSessionStream(operationId, peerIdString, stream);
+
+            const streamMessage = this.createStreamMessage(message, operationId, messageType);
+
+            this.logger.trace(
+                `Sending message to ${peerIdString}. protocol: ${protocol}, messageType: ${messageType}, operationId: ${operationId}`,
+            );
+
+            errorMessage = `send message`;
+            operationStart = Date.now();
+            await this._sendMessageToStream(stream, streamMessage);
+            operationEnd = Date.now();
+            if (timeoutSignal.aborted) {
+                throw abortError;
+            }
+
+            errorMessage = `read response`;
+            operationStart = Date.now();
             response = await this._readMessageFromStream(
                 stream,
                 this.isResponseValid.bind(this),
                 peerIdString,
             );
-
-            if (timeoutController.signal.aborted) {
-                throw Error('Message timed out!');
+            operationEnd = Date.now();
+            if (timeoutSignal.aborted) {
+                throw abortError;
             }
 
-            timeoutController.signal.removeEventListener('abort', abortSignalEventListener);
-            timeoutController.clear();
+            this.logger.trace(
+                `Receiving response from ${peerIdString}. protocol: ${protocol}, messageType: ${
+                    response.message?.header?.messageType
+                }, operationId: ${operationId}, execution time: ${
+                    operationEnd - operationStart
+                } ms.`,
+            );
 
-            readResponseEnd = Date.now();
+            if (!response.valid) {
+                nackMessage.data.errorMessage = 'Invalid response';
+                return nackMessage;
+            }
         } catch (error) {
-            timeoutController.signal.removeEventListener('abort', abortSignalEventListener);
-            timeoutController.clear();
-
-            readResponseEnd = Date.now();
-            nackMessage.data.errorMessage = `Unable to read response from peer ${peerIdString}. protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}, execution time: ${
-                readResponseEnd - readResponseStart
-            } ms. Error: ${error.message}`;
-
+            nackMessage.data.errorMessage = `Unable to ${errorMessage} from peer ${peerIdString}. protocol: ${protocol}, messageType: ${messageType} , operationId: ${operationId}. Execution time: ${
+                (operationEnd ?? Date.now()) - operationStart
+            } ms. Error: ${error.message.slice(0, 145)}`;
             return nackMessage;
+        } finally {
+            timeoutSignal.removeEventListener('abort', onAbort);
         }
-
-        this.logger.trace(
-            `Receiving response from ${peerIdString}. protocol: ${protocol}, messageType: ${
-                response.message?.header?.messageType
-            }, operationId: ${operationId}, execution time: ${
-                readResponseEnd - readResponseStart
-            } ms.`,
-        );
-
-        if (!response.valid) {
-            nackMessage.data.errorMessage = 'Invalid response';
-
-            return nackMessage;
-        }
-
         return response.message;
     }
 


### PR DESCRIPTION
Currently node only aborts message if reading from the stream takes longer than the specified timeout.
This PR ensure that the timeout is measured from the start of the operation, which includes dialing the peer (stream creation) and writing to the stream aswell.
The timeout abort controller dependency is removed as it is not necessary since node v16.