### PR TITLE
fix: batch get command queue

### DIFF
--- a/src/commands/command-executor.js
+++ b/src/commands/command-executor.js
@@ -196,6 +196,8 @@ class CommandExecutor {
         }
         await this.queue.resume();
         this.worker.resume();
+        await this.queueBatchGet.resume();
+        this.batchGetWorker.resume();
     }
 
     /**


### PR DESCRIPTION
Batch get commands are not running because queue is never resumed