### PR TITLE
Get fix - Remove extra arg when metadata is included

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "origintrail_node",
-    "version": "8.2.1+hotfix.1",
+    "version": "8.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "origintrail_node",
-            "version": "8.2.1+hotfix.1",
+            "version": "8.2.2",
             "license": "ISC",
             "dependencies": {
                 "@comunica/query-sparql": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "origintrail_node",
-    "version": "8.2.1",
+    "version": "8.2.2",
     "description": "OTNode V8",
     "main": "index.js",
     "type": "module",

--- a/src/commands/protocols/get/sender/get-command.js
+++ b/src/commands/protocols/get/sender/get-command.js
@@ -209,7 +209,6 @@ class GetCommand extends Command {
                 blockchain,
                 contract,
                 knowledgeCollectionId,
-                knowledgeAssetId,
                 repository,
             );
             promises.push(metadataPromise);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes an extra argument from the metadata retrieval in GET command and bumps the package version to 8.2.2.
> 
> - **Backend (GET command)**:
>   - Fix: Update `getAssertionMetadata` invocation in `src/commands/protocols/get/sender/get-command.js` by removing the extra `knowledgeAssetId` arg; now passes `blockchain`, `contract`, `knowledgeCollectionId`, `repository`.
> - **Versioning**:
>   - Bump `version` to `8.2.2` in `package.json` and `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7a015f212476486ff7e7a45be0b4abeaadbf571. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->