### PR TITLE
8.2.2 release testnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "origintrail_node",
-    "version": "8.2.1+hotfix.1",
+    "version": "8.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "origintrail_node",
-            "version": "8.2.1+hotfix.1",
+            "version": "8.2.2",
             "license": "ISC",
             "dependencies": {
                 "@comunica/query-sparql": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "origintrail_node",
-    "version": "8.2.1",
+    "version": "8.2.2",
     "description": "OTNode V8",
     "main": "index.js",
     "type": "module",

--- a/src/commands/protocols/get/sender/get-command.js
+++ b/src/commands/protocols/get/sender/get-command.js
@@ -209,7 +209,6 @@ class GetCommand extends Command {
                 blockchain,
                 contract,
                 knowledgeCollectionId,
-                knowledgeAssetId,
                 repository,
             );
             promises.push(metadataPromise);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `getAssertionMetadata` call in GET flow to remove `knowledgeAssetId` and bumps version to 8.2.2.
> 
> - **Backend – GET protocol**:
>   - Update `src/commands/protocols/get/sender/get-command.js` to call `tripleStoreService.getAssertionMetadata(blockchain, contract, knowledgeCollectionId, repository)` (removes `knowledgeAssetId`).
> - **Release**:
>   - Bump version to `8.2.2` in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca656efae40473950b1f02875537a947964ad38d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->