### PR TITLE
Feature/improve publish success rate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "origintrail_node",
-    "version": "8.2.2",
+    "version": "8.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "origintrail_node",
-            "version": "8.2.2",
+            "version": "8.2.3",
             "license": "ISC",
             "dependencies": {
                 "@comunica/query-sparql": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "origintrail_node",
-    "version": "8.2.2",
+    "version": "8.2.3",
     "description": "OTNode V8",
     "main": "index.js",
     "type": "module",

--- a/src/commands/protocols/publish/publish-finalization-command.js
+++ b/src/commands/protocols/publish/publish-finalization-command.js
@@ -33,6 +33,8 @@ class PublishFinalizationCommand extends Command {
         const { id, publishOperationId, merkleRoot, byteSize } = eventData;
         const { blockchain, contractAddress } = event;
         const operationId = this.operationIdService.generateId();
+        const ual = this.ualService.deriveUAL(blockchain, contractAddress, id);
+
         this.operationIdService.emitChangeEvent(
             OPERATION_ID_STATUS.PUBLISH_FINALIZATION.PUBLISH_FINALIZATION_START,
             operationId,
@@ -71,7 +73,9 @@ class PublishFinalizationCommand extends Command {
             assertion = result.assertion;
             publisherPeerId = result.remotePeerId;
         } catch (error) {
-            this.logger.error(`Failed to read cached publish data: ${error.message}`); // TODO: Make this log more descriptive
+            this.logger.error(
+                `[Cache] Failed to read cached publish data for UAL ${ual} (publishOperationId: ${publishOperationId}, txHash: ${txHash}, operationId: ${operationId}): ${error.message}`,
+            );
             this.operationIdService.emitChangeEvent(
                 OPERATION_ID_STATUS.FAILED,
                 operationId,
@@ -80,8 +84,6 @@ class PublishFinalizationCommand extends Command {
             );
             return Command.empty();
         }
-
-        const ual = this.ualService.deriveUAL(blockchain, contractAddress, id);
 
         try {
             await this.validatePublishData(merkleRoot, cachedMerkleRoot, byteSize, assertion, ual);
@@ -185,23 +187,24 @@ class PublishFinalizationCommand extends Command {
 
     async readWithRetries(publishOperationId) {
         let attempt = 0;
+        const datasetPath = this.fileService.getPendingStorageDocumentPath(publishOperationId);
 
         while (attempt < MAX_RETRIES_READ_CACHED_PUBLISH_DATA) {
             try {
-                const datasetPath =
-                    this.fileService.getPendingStorageDocumentPath(publishOperationId);
                 // eslint-disable-next-line no-await-in-loop
                 const cachedData = await this.fileService.readFile(datasetPath, true);
                 return cachedData;
             } catch (error) {
                 attempt += 1;
-
                 // eslint-disable-next-line no-await-in-loop
                 await new Promise((resolve) => {
                     setTimeout(resolve, RETRY_DELAY_READ_CACHED_PUBLISH_DATA);
                 });
             }
         }
+        this.logger.error(
+            `[Cache] Exhausted retries reading cached publish data (publishOperationId: ${publishOperationId}, path: ${datasetPath}).`,
+        );
         // TODO: Mark this operation as failed
         throw new Error('Failed to read cached publish data');
     }

--- a/src/commands/protocols/publish/publish-finalization-command.js
+++ b/src/commands/protocols/publish/publish-finalization-command.js
@@ -72,9 +72,9 @@ class PublishFinalizationCommand extends Command {
             cachedMerkleRoot = result.merkleRoot;
             assertion = result.assertion;
             publisherPeerId = result.remotePeerId;
-        } catch (error) {
-            this.logger.error(
-                `[Cache] Failed to read cached publish data for UAL ${ual} (publishOperationId: ${publishOperationId}, txHash: ${txHash}, operationId: ${operationId}): ${error.message}`,
+        } catch (_error) {
+            this.logger.warn(
+                `[Cache] Failed to read cached publish data for UAL ${ual} (publishOperationId: ${publishOperationId}, txHash: ${txHash}, operationId: ${operationId})`,
             );
             this.operationIdService.emitChangeEvent(
                 OPERATION_ID_STATUS.FAILED,
@@ -202,7 +202,7 @@ class PublishFinalizationCommand extends Command {
                 });
             }
         }
-        this.logger.error(
+        this.logger.warn(
             `[Cache] Exhausted retries reading cached publish data (publishOperationId: ${publishOperationId}, path: ${datasetPath}).`,
         );
         // TODO: Mark this operation as failed

--- a/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
+++ b/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
@@ -177,12 +177,26 @@ class OtBlazegraph extends OtTripleStore {
     }
 
     async queryVoid(repository, query, timeout) {
-        return axios.post(this.repositories[repository].sparqlEndpoint, query, {
-            headers: {
-                'Content-Type': 'application/sparql-update; charset=UTF-8',
-                'X-BIGDATA-MAX-QUERY-MILLIS': timeout,
-            },
-        });
+        try {
+            return axios.post(this.repositories[repository].sparqlEndpoint, query, {
+                headers: {
+                    'Content-Type': 'application/sparql-update; charset=UTF-8',
+                    'X-BIGDATA-MAX-QUERY-MILLIS': timeout,
+                },
+            });
+        } catch (error) {
+            const status = error?.response?.status;
+            const dataSnippet =
+                typeof error?.response?.data === 'string'
+                    ? error.response.data.slice(0, 200)
+                    : '';
+            this.logger.error(
+                `[OtBlazegraph.queryVoid] Update failed for ${repository} (status: ${status}): ${error.message}${
+                    dataSnippet ? ` | data: ${dataSnippet}` : ''
+                } | query: ${snippet || '<empty>'}`,
+            );
+            throw error;
+        }
     }
 
     async deleteRepository(repository) {

--- a/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
+++ b/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
@@ -178,7 +178,7 @@ class OtBlazegraph extends OtTripleStore {
 
     async queryVoid(repository, query, timeout) {
         try {
-            return axios.post(this.repositories[repository].sparqlEndpoint, query, {
+            return await axios.post(this.repositories[repository].sparqlEndpoint, query, {
                 headers: {
                     'Content-Type': 'application/sparql-update; charset=UTF-8',
                     'X-BIGDATA-MAX-QUERY-MILLIS': timeout,
@@ -187,13 +187,11 @@ class OtBlazegraph extends OtTripleStore {
         } catch (error) {
             const status = error?.response?.status;
             const dataSnippet =
-                typeof error?.response?.data === 'string'
-                    ? error.response.data.slice(0, 200)
-                    : '';
+                typeof error?.response?.data === 'string' ? error.response.data.slice(0, 200) : '';
             this.logger.error(
-                `[OtBlazegraph.queryVoid] Update failed for ${repository} (status: ${status}): ${error.message}${
-                    dataSnippet ? ` | data: ${dataSnippet}` : ''
-                } | query: ${snippet || '<empty>'}`,
+                `[OtBlazegraph.queryVoid] Update failed for ${repository} (status: ${status}): ${
+                    error.message
+                }${dataSnippet ? ` | data: ${dataSnippet}` : ''}`,
             );
             throw error;
         }

--- a/src/service/publish-service.js
+++ b/src/service/publish-service.js
@@ -69,16 +69,15 @@ class PublishService extends OperationService {
         // }
 
         // 2. Check if all responses have been received
-            // 2.1 If minimum replication is reached, mark the operation as completed
+        // 2.1 If minimum replication is reached, mark the operation as completed
 
         const record = await this.operationIdService.getOperationIdRecord(operationId);
         if (record?.minAcksReached) return;
 
-        
         if (completedNumber >= minAckResponses) {
             this.logger.info(
                 `[PUBLISH] Minimum replication reached for operationId: ${operationId}, ` +
-                `datasetRoot: ${datasetRoot}, completed: ${completedNumber}/${minAckResponses}`,
+                    `datasetRoot: ${datasetRoot}, completed: ${completedNumber}/${minAckResponses}`,
             );
             await this.markOperationAsCompleted(
                 operationId,
@@ -89,11 +88,11 @@ class PublishService extends OperationService {
             await this.repositoryModuleManager.updateMinAcksReached(operationId, true);
             this.logResponsesSummary(completedNumber, failedNumber);
         }
-            // 2.2 Otherwise, mark as failed
-        else if (totalResponses === numberOfFoundNodes)  {
+        // 2.2 Otherwise, mark as failed
+        else if (totalResponses === numberOfFoundNodes) {
             this.logger.warn(
                 `[PUBLISH] Failed for operationId: ${operationId}, ` +
-                `only ${completedNumber}/${minAckResponses} nodes responded successfully`,
+                    `only ${completedNumber}/${minAckResponses} nodes responded successfully`,
             );
             await this.markOperationAsFailed(
                 operationId,

--- a/src/service/publish-service.js
+++ b/src/service/publish-service.js
@@ -69,32 +69,43 @@ class PublishService extends OperationService {
         // }
 
         // 2. Check if all responses have been received
-        if (totalResponses === numberOfFoundNodes) {
             // 2.1 If minimum replication is reached, mark the operation as completed
-            if (completedNumber >= minAckResponses) {
-                await this.markOperationAsCompleted(
-                    operationId,
-                    blockchain,
-                    null,
-                    this.completedStatuses,
-                );
-                await this.repositoryModuleManager.updateMinAcksReached(operationId, true);
-                this.logResponsesSummary(completedNumber, failedNumber);
-            }
+
+        const record = await this.operationIdService.getOperationIdRecord(operationId);
+        if (record?.minAcksReached) return;
+
+        
+        if (completedNumber >= minAckResponses) {
+            this.logger.info(
+                `[PUBLISH] Minimum replication reached for operationId: ${operationId}, ` +
+                `datasetRoot: ${datasetRoot}, completed: ${completedNumber}/${minAckResponses}`,
+            );
+            await this.markOperationAsCompleted(
+                operationId,
+                blockchain,
+                null,
+                this.completedStatuses,
+            );
+            await this.repositoryModuleManager.updateMinAcksReached(operationId, true);
+            this.logResponsesSummary(completedNumber, failedNumber);
+        }
             // 2.2 Otherwise, mark as failed
-            else {
-                await this.markOperationAsFailed(
-                    operationId,
-                    blockchain,
-                    'Not replicated to enough nodes!',
-                    this.errorType,
-                );
-                this.operationIdService.emitChangeEvent(
-                    OPERATION_ID_STATUS.PUBLISH.PUBLISH_FAILED,
-                    operationId,
-                );
-                this.logResponsesSummary(completedNumber, failedNumber);
-            }
+        else if (totalResponses === numberOfFoundNodes)  {
+            this.logger.warn(
+                `[PUBLISH] Failed for operationId: ${operationId}, ` +
+                `only ${completedNumber}/${minAckResponses} nodes responded successfully`,
+            );
+            await this.markOperationAsFailed(
+                operationId,
+                blockchain,
+                'Not replicated to enough nodes!',
+                this.errorType,
+            );
+            this.operationIdService.emitChangeEvent(
+                OPERATION_ID_STATUS.PUBLISH.PUBLISH_FAILED,
+                operationId,
+            );
+            this.logResponsesSummary(completedNumber, failedNumber);
         }
         //  else {
         //     // 3. Not all responses have arrived yet.


### PR DESCRIPTION
# Description

  * Improved publish flow now completes as soon as the minimum acknowledgements are reached and skips redundant
  processing once minAcksReached is set, only failing when all contacted nodes have responded unsuccessfully
  (src/service/publish-service.js). 
  * Cache handling logs are more descriptive and downgraded to warnings for
  cache-miss scenarios to avoid noisy errors while still emitting state changes (src/commands/protocols/publish/
  publish-finalization-command.js).
 * Blazegraph write failures now log HTTP status plus response/query snippets
  to aid debugging (src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publish now completes once minimum acknowledgements are met (and only fails after all responses if insufficient), with clearer cache logs and enhanced Blazegraph update error reporting.
> 
> - **Publish flow (`src/service/publish-service.js`)**:
>   - Complete as soon as `minAckResponses` is reached; skip further processing via `minAcksReached` guard.
>   - Fail only when all contacted nodes responded and successes < `minAckResponses`.
>   - Added concise info/warn logs and response summary.
> - **Publish finalization/cache (`src/commands/protocols/publish/publish-finalization-command.js`)**:
>   - Derive `ual` earlier for logging/context.
>   - Downgrade cache read failure to warnings; add warning when retry budget is exhausted.
>   - Refactor to compute `datasetPath` once before retry loop.
> - **Triple store (`src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js`)**:
>   - Wrap `queryVoid` in try/catch; log HTTP status and response data snippet on failure; rethrow error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17016facb1d42c863290a19c376a8c7419a21f1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->