### PR TITLE
8.2.3 prerelease testnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "origintrail_node",
-    "version": "8.2.2",
+    "version": "8.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "origintrail_node",
-            "version": "8.2.2",
+            "version": "8.2.3",
             "license": "ISC",
             "dependencies": {
                 "@comunica/query-sparql": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "origintrail_node",
-    "version": "8.2.2",
+    "version": "8.2.3",
     "description": "OTNode V8",
     "main": "index.js",
     "type": "module",

--- a/src/commands/protocols/publish/publish-finalization-command.js
+++ b/src/commands/protocols/publish/publish-finalization-command.js
@@ -33,6 +33,8 @@ class PublishFinalizationCommand extends Command {
         const { id, publishOperationId, merkleRoot, byteSize } = eventData;
         const { blockchain, contractAddress } = event;
         const operationId = this.operationIdService.generateId();
+        const ual = this.ualService.deriveUAL(blockchain, contractAddress, id);
+
         this.operationIdService.emitChangeEvent(
             OPERATION_ID_STATUS.PUBLISH_FINALIZATION.PUBLISH_FINALIZATION_START,
             operationId,
@@ -71,7 +73,9 @@ class PublishFinalizationCommand extends Command {
             assertion = result.assertion;
             publisherPeerId = result.remotePeerId;
         } catch (error) {
-            this.logger.error(`Failed to read cached publish data: ${error.message}`); // TODO: Make this log more descriptive
+            this.logger.error(
+                `[Cache] Failed to read cached publish data for UAL ${ual} (publishOperationId: ${publishOperationId}, txHash: ${txHash}, operationId: ${operationId}): ${error.message}`,
+            );
             this.operationIdService.emitChangeEvent(
                 OPERATION_ID_STATUS.FAILED,
                 operationId,
@@ -80,8 +84,6 @@ class PublishFinalizationCommand extends Command {
             );
             return Command.empty();
         }
-
-        const ual = this.ualService.deriveUAL(blockchain, contractAddress, id);
 
         try {
             await this.validatePublishData(merkleRoot, cachedMerkleRoot, byteSize, assertion, ual);
@@ -185,23 +187,24 @@ class PublishFinalizationCommand extends Command {
 
     async readWithRetries(publishOperationId) {
         let attempt = 0;
+        const datasetPath = this.fileService.getPendingStorageDocumentPath(publishOperationId);
 
         while (attempt < MAX_RETRIES_READ_CACHED_PUBLISH_DATA) {
             try {
-                const datasetPath =
-                    this.fileService.getPendingStorageDocumentPath(publishOperationId);
                 // eslint-disable-next-line no-await-in-loop
                 const cachedData = await this.fileService.readFile(datasetPath, true);
                 return cachedData;
             } catch (error) {
                 attempt += 1;
-
                 // eslint-disable-next-line no-await-in-loop
                 await new Promise((resolve) => {
                     setTimeout(resolve, RETRY_DELAY_READ_CACHED_PUBLISH_DATA);
                 });
             }
         }
+        this.logger.error(
+            `[Cache] Exhausted retries reading cached publish data (publishOperationId: ${publishOperationId}, path: ${datasetPath}).`,
+        );
         // TODO: Mark this operation as failed
         throw new Error('Failed to read cached publish data');
     }

--- a/src/commands/protocols/publish/publish-finalization-command.js
+++ b/src/commands/protocols/publish/publish-finalization-command.js
@@ -72,9 +72,9 @@ class PublishFinalizationCommand extends Command {
             cachedMerkleRoot = result.merkleRoot;
             assertion = result.assertion;
             publisherPeerId = result.remotePeerId;
-        } catch (error) {
-            this.logger.error(
-                `[Cache] Failed to read cached publish data for UAL ${ual} (publishOperationId: ${publishOperationId}, txHash: ${txHash}, operationId: ${operationId}): ${error.message}`,
+        } catch (_error) {
+            this.logger.warn(
+                `[Cache] Failed to read cached publish data for UAL ${ual} (publishOperationId: ${publishOperationId}, txHash: ${txHash}, operationId: ${operationId})`,
             );
             this.operationIdService.emitChangeEvent(
                 OPERATION_ID_STATUS.FAILED,
@@ -202,7 +202,7 @@ class PublishFinalizationCommand extends Command {
                 });
             }
         }
-        this.logger.error(
+        this.logger.warn(
             `[Cache] Exhausted retries reading cached publish data (publishOperationId: ${publishOperationId}, path: ${datasetPath}).`,
         );
         // TODO: Mark this operation as failed

--- a/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
+++ b/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
@@ -177,12 +177,26 @@ class OtBlazegraph extends OtTripleStore {
     }
 
     async queryVoid(repository, query, timeout) {
-        return axios.post(this.repositories[repository].sparqlEndpoint, query, {
-            headers: {
-                'Content-Type': 'application/sparql-update; charset=UTF-8',
-                'X-BIGDATA-MAX-QUERY-MILLIS': timeout,
-            },
-        });
+        try {
+            return axios.post(this.repositories[repository].sparqlEndpoint, query, {
+                headers: {
+                    'Content-Type': 'application/sparql-update; charset=UTF-8',
+                    'X-BIGDATA-MAX-QUERY-MILLIS': timeout,
+                },
+            });
+        } catch (error) {
+            const status = error?.response?.status;
+            const dataSnippet =
+                typeof error?.response?.data === 'string'
+                    ? error.response.data.slice(0, 200)
+                    : '';
+            this.logger.error(
+                `[OtBlazegraph.queryVoid] Update failed for ${repository} (status: ${status}): ${error.message}${
+                    dataSnippet ? ` | data: ${dataSnippet}` : ''
+                } | query: ${snippet || '<empty>'}`,
+            );
+            throw error;
+        }
     }
 
     async deleteRepository(repository) {

--- a/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
+++ b/src/modules/triple-store/implementation/ot-blazegraph/ot-blazegraph.js
@@ -178,7 +178,7 @@ class OtBlazegraph extends OtTripleStore {
 
     async queryVoid(repository, query, timeout) {
         try {
-            return axios.post(this.repositories[repository].sparqlEndpoint, query, {
+            return await axios.post(this.repositories[repository].sparqlEndpoint, query, {
                 headers: {
                     'Content-Type': 'application/sparql-update; charset=UTF-8',
                     'X-BIGDATA-MAX-QUERY-MILLIS': timeout,
@@ -187,13 +187,11 @@ class OtBlazegraph extends OtTripleStore {
         } catch (error) {
             const status = error?.response?.status;
             const dataSnippet =
-                typeof error?.response?.data === 'string'
-                    ? error.response.data.slice(0, 200)
-                    : '';
+                typeof error?.response?.data === 'string' ? error.response.data.slice(0, 200) : '';
             this.logger.error(
-                `[OtBlazegraph.queryVoid] Update failed for ${repository} (status: ${status}): ${error.message}${
-                    dataSnippet ? ` | data: ${dataSnippet}` : ''
-                } | query: ${snippet || '<empty>'}`,
+                `[OtBlazegraph.queryVoid] Update failed for ${repository} (status: ${status}): ${
+                    error.message
+                }${dataSnippet ? ` | data: ${dataSnippet}` : ''}`,
             );
             throw error;
         }

--- a/src/service/publish-service.js
+++ b/src/service/publish-service.js
@@ -69,16 +69,15 @@ class PublishService extends OperationService {
         // }
 
         // 2. Check if all responses have been received
-            // 2.1 If minimum replication is reached, mark the operation as completed
+        // 2.1 If minimum replication is reached, mark the operation as completed
 
         const record = await this.operationIdService.getOperationIdRecord(operationId);
         if (record?.minAcksReached) return;
 
-        
         if (completedNumber >= minAckResponses) {
             this.logger.info(
                 `[PUBLISH] Minimum replication reached for operationId: ${operationId}, ` +
-                `datasetRoot: ${datasetRoot}, completed: ${completedNumber}/${minAckResponses}`,
+                    `datasetRoot: ${datasetRoot}, completed: ${completedNumber}/${minAckResponses}`,
             );
             await this.markOperationAsCompleted(
                 operationId,
@@ -89,11 +88,11 @@ class PublishService extends OperationService {
             await this.repositoryModuleManager.updateMinAcksReached(operationId, true);
             this.logResponsesSummary(completedNumber, failedNumber);
         }
-            // 2.2 Otherwise, mark as failed
-        else if (totalResponses === numberOfFoundNodes)  {
+        // 2.2 Otherwise, mark as failed
+        else if (totalResponses === numberOfFoundNodes) {
             this.logger.warn(
                 `[PUBLISH] Failed for operationId: ${operationId}, ` +
-                `only ${completedNumber}/${minAckResponses} nodes responded successfully`,
+                    `only ${completedNumber}/${minAckResponses} nodes responded successfully`,
             );
             await this.markOperationAsFailed(
                 operationId,

--- a/src/service/publish-service.js
+++ b/src/service/publish-service.js
@@ -69,32 +69,43 @@ class PublishService extends OperationService {
         // }
 
         // 2. Check if all responses have been received
-        if (totalResponses === numberOfFoundNodes) {
             // 2.1 If minimum replication is reached, mark the operation as completed
-            if (completedNumber >= minAckResponses) {
-                await this.markOperationAsCompleted(
-                    operationId,
-                    blockchain,
-                    null,
-                    this.completedStatuses,
-                );
-                await this.repositoryModuleManager.updateMinAcksReached(operationId, true);
-                this.logResponsesSummary(completedNumber, failedNumber);
-            }
+
+        const record = await this.operationIdService.getOperationIdRecord(operationId);
+        if (record?.minAcksReached) return;
+
+        
+        if (completedNumber >= minAckResponses) {
+            this.logger.info(
+                `[PUBLISH] Minimum replication reached for operationId: ${operationId}, ` +
+                `datasetRoot: ${datasetRoot}, completed: ${completedNumber}/${minAckResponses}`,
+            );
+            await this.markOperationAsCompleted(
+                operationId,
+                blockchain,
+                null,
+                this.completedStatuses,
+            );
+            await this.repositoryModuleManager.updateMinAcksReached(operationId, true);
+            this.logResponsesSummary(completedNumber, failedNumber);
+        }
             // 2.2 Otherwise, mark as failed
-            else {
-                await this.markOperationAsFailed(
-                    operationId,
-                    blockchain,
-                    'Not replicated to enough nodes!',
-                    this.errorType,
-                );
-                this.operationIdService.emitChangeEvent(
-                    OPERATION_ID_STATUS.PUBLISH.PUBLISH_FAILED,
-                    operationId,
-                );
-                this.logResponsesSummary(completedNumber, failedNumber);
-            }
+        else if (totalResponses === numberOfFoundNodes)  {
+            this.logger.warn(
+                `[PUBLISH] Failed for operationId: ${operationId}, ` +
+                `only ${completedNumber}/${minAckResponses} nodes responded successfully`,
+            );
+            await this.markOperationAsFailed(
+                operationId,
+                blockchain,
+                'Not replicated to enough nodes!',
+                this.errorType,
+            );
+            this.operationIdService.emitChangeEvent(
+                OPERATION_ID_STATUS.PUBLISH.PUBLISH_FAILED,
+                operationId,
+            );
+            this.logResponsesSummary(completedNumber, failedNumber);
         }
         //  else {
         //     // 3. Not all responses have arrived yet.


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes publish once minimum acknowledgements are reached (with duplicate-guard), fails when responses are exhausted, and adds stronger logging/error handling in publish finalization and Blazegraph updates; bumps version to 8.2.3.
> 
> - **Publish flow**:
>   - Completes operation as soon as `minAckResponses` are met, independent of total responses; guards with `minAcksReached` to prevent duplicate completion.
>   - When all responses are in and minimum not met, marks as failed and emits `PUBLISH_FAILED`.
>   - Improved info/warn logs and response summary reporting.
> - **Publish finalization (`src/commands/protocols/publish/publish-finalization-command.js`)**:
>   - Derives `ual` earlier; enhanced warnings when cached publish data read fails and when retry attempts are exhausted.
>   - Refactors `readWithRetries` to compute `datasetPath` once and log path on failure.
> - **Triple store (Blazegraph)**:
>   - Wraps `queryVoid` in try/catch with detailed error logging (HTTP status and data snippet) and rethrows.
> - **Version**:
>   - Bump `version` to `8.2.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43d08f242d88287d752c6b699ea43836d2d88c72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->