### PR TITLE
Fix operation concurrency and response handling

### DIFF
--- a/src/commands/protocols/common/handle-protocol-message-command.js
+++ b/src/commands/protocols/common/handle-protocol-message-command.js
@@ -126,13 +126,19 @@ class HandleProtocolMessageCommand extends Command {
             this.errorType,
         );
 
-        await this.networkModuleManager.sendMessageResponse(
-            protocol,
-            remotePeerId,
-            NETWORK_MESSAGE_TYPES.RESPONSES.NACK,
-            operationId,
-            { errorMessage },
-        );
+        try {
+            await this.networkModuleManager.sendMessageResponse(
+                protocol,
+                remotePeerId,
+                NETWORK_MESSAGE_TYPES.RESPONSES.NACK,
+                operationId,
+                { errorMessage },
+            );
+        } catch (sendErr) {
+            this.logger.debug(
+                `Failed to send NACK to ${remotePeerId} for operation ${operationId}: ${sendErr.message}`,
+            );
+        }
         this.networkModuleManager.removeCachedSession(operationId, remotePeerId);
     }
 }

--- a/src/controllers/http-api/v1/result-http-api-controller-v1.js
+++ b/src/controllers/http-api/v1/result-http-api-controller-v1.js
@@ -55,22 +55,33 @@ class ResultController extends BaseController {
                     case 'update': {
                         const minAcksReached = handlerRecord.minAcksReached || false;
                         response.data = { ...response.data, minAcksReached };
-                        if (minAcksReached) {
-                            const publisherNodeSignature = (
-                                await this.signatureService.getSignaturesFromStorage(
-                                    PUBLISHER_NODE_SIGNATURES_FOLDER,
-                                    operationId,
-                                )
-                            )[0];
-                            const signatures = await this.signatureService.getSignaturesFromStorage(
-                                NETWORK_SIGNATURES_FOLDER,
-                                operationId,
-                            );
-                            response.data = {
-                                ...response.data,
-                                publisherNodeSignature,
-                                signatures,
-                            };
+                        const shouldIncludeSignatures =
+                            minAcksReached ||
+                            handlerRecord.status === OPERATION_ID_STATUS.COMPLETED;
+                        if (shouldIncludeSignatures) {
+                            try {
+                                const publisherNodeSignature = (
+                                    await this.signatureService.getSignaturesFromStorage(
+                                        PUBLISHER_NODE_SIGNATURES_FOLDER,
+                                        operationId,
+                                    )
+                                )[0];
+                                const signatures =
+                                    await this.signatureService.getSignaturesFromStorage(
+                                        NETWORK_SIGNATURES_FOLDER,
+                                        operationId,
+                                    );
+                                response.data = {
+                                    ...response.data,
+                                    minAcksReached: true,
+                                    publisherNodeSignature,
+                                    signatures,
+                                };
+                            } catch (e) {
+                                this.logger.warn(
+                                    `Failed to read signatures for operationId ${operationId}: ${e.message}`,
+                                );
+                            }
                         }
                         break;
                     }

--- a/src/service/ask-service.js
+++ b/src/service/ask-service.js
@@ -1,4 +1,3 @@
-import { Mutex } from 'async-mutex';
 import OperationService from './operation-service.js';
 import {
     OPERATION_ID_STATUS,
@@ -21,7 +20,6 @@ class AskService extends OperationService {
             OPERATION_ID_STATUS.ASK.ASK_END,
             OPERATION_ID_STATUS.COMPLETED,
         ];
-        this.operationMutex = new Mutex();
     }
 
     async processResponse(command, responseStatus, responseData) {

--- a/src/service/batch-get-service.js
+++ b/src/service/batch-get-service.js
@@ -1,4 +1,3 @@
-import { Mutex } from 'async-mutex';
 import OperationService from './operation-service.js';
 import {
     OPERATION_ID_STATUS,
@@ -19,7 +18,6 @@ class BatchGetService extends OperationService {
             OPERATION_ID_STATUS.BATCH_GET.BATCH_GET_END,
             OPERATION_ID_STATUS.COMPLETED,
         ];
-        this.operationMutex = new Mutex();
     }
 }
 

--- a/src/service/finality-service.js
+++ b/src/service/finality-service.js
@@ -1,4 +1,3 @@
-import { Mutex } from 'async-mutex';
 import OperationService from './operation-service.js';
 import {
     OPERATION_ID_STATUS,
@@ -26,7 +25,6 @@ class FinalityService extends OperationService {
         this.repositoryModuleManager = ctx.repositoryModuleManager;
         this.blockchainModuleManager = ctx.blockchainModuleManager;
         this.paranetService = ctx.paranetService;
-        this.operationMutex = new Mutex();
     }
 
     async processResponse(operationId, blockchain, responseStatus, responseData) {

--- a/src/service/get-service.js
+++ b/src/service/get-service.js
@@ -1,4 +1,3 @@
-import { Mutex } from 'async-mutex';
 import OperationService from './operation-service.js';
 import {
     OPERATION_ID_STATUS,
@@ -22,7 +21,6 @@ class GetService extends OperationService {
             OPERATION_ID_STATUS.GET.GET_END,
             OPERATION_ID_STATUS.COMPLETED,
         ];
-        this.operationMutex = new Mutex();
     }
 
     async processResponse(command, responseStatus, responseData) {

--- a/src/service/operation-service.js
+++ b/src/service/operation-service.js
@@ -5,6 +5,9 @@ import {
     OPERATION_STATUS,
 } from '../constants/constants.js';
 
+const MUTEX_TTL_MS = 5 * 60 * 1000;
+const MUTEX_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
 class OperationService {
     constructor(ctx) {
         this.logger = ctx.logger;
@@ -12,6 +15,12 @@ class OperationService {
         this.operationIdService = ctx.operationIdService;
         this.commandExecutor = ctx.commandExecutor;
         this._operationMutexes = new Map();
+        this._terminalOperations = new Map();
+
+        this._sweepInterval = setInterval(() => this._sweepStaleMutexes(), MUTEX_SWEEP_INTERVAL_MS);
+        if (this._sweepInterval.unref) {
+            this._sweepInterval.unref();
+        }
     }
 
     _getOperationMutex(operationId) {
@@ -21,8 +30,22 @@ class OperationService {
         return this._operationMutexes.get(operationId);
     }
 
-    _cleanupOperationMutex(operationId) {
-        this._operationMutexes.delete(operationId);
+    _markOperationTerminal(operationId) {
+        this._terminalOperations.set(operationId, Date.now());
+    }
+
+    _isOperationTerminal(operationId) {
+        return this._terminalOperations.has(operationId);
+    }
+
+    _sweepStaleMutexes() {
+        const now = Date.now();
+        for (const [operationId, terminatedAt] of this._terminalOperations) {
+            if (now - terminatedAt >= MUTEX_TTL_MS) {
+                this._operationMutexes.delete(operationId);
+                this._terminalOperations.delete(operationId);
+            }
+        }
     }
 
     getOperationName() {
@@ -45,6 +68,10 @@ class OperationService {
         const self = this;
         const mutex = this._getOperationMutex(operationId);
         await mutex.runExclusive(async () => {
+            if (self._isOperationTerminal(operationId)) {
+                self.logger.debug(`Skipping late response for terminal operation ${operationId}`);
+                return;
+            }
             await self.repositoryModuleManager.createOperationResponseRecord(
                 responseStatus,
                 this.operationName,
@@ -79,7 +106,7 @@ class OperationService {
         endStatuses,
         options = {},
     ) {
-        this._cleanupOperationMutex(operationId);
+        this._markOperationTerminal(operationId);
         const { reuseExistingCache = false } = options;
         this.logger.info(`Finalizing ${this.operationName} for operationId: ${operationId}`);
 
@@ -113,7 +140,7 @@ class OperationService {
     }
 
     async markOperationAsFailed(operationId, blockchain, message, errorType) {
-        this._cleanupOperationMutex(operationId);
+        this._markOperationTerminal(operationId);
         this.logger.info(`${this.operationName} for operationId: ${operationId} failed.`);
 
         await this.operationIdService.removeOperationIdCache(operationId);

--- a/src/service/operation-service.js
+++ b/src/service/operation-service.js
@@ -64,7 +64,7 @@ class OperationService {
     }
 
     async getResponsesStatuses(responseStatus, errorMessage, operationId) {
-        let responses = 0;
+        let responses = [];
         const self = this;
         const mutex = this._getOperationMutex(operationId);
         await mutex.runExclusive(async () => {

--- a/src/service/operation-service.js
+++ b/src/service/operation-service.js
@@ -85,10 +85,9 @@ class OperationService {
         });
 
         const operationIdStatuses = {};
-        for (const response of responses) {
-            if (!operationIdStatuses[operationId])
-                operationIdStatuses[operationId] = { failedNumber: 0, completedNumber: 0 };
+        operationIdStatuses[operationId] = { failedNumber: 0, completedNumber: 0 };
 
+        for (const response of responses) {
             if (response.status === OPERATION_REQUEST_STATUS.FAILED) {
                 operationIdStatuses[operationId].failedNumber += 1;
             } else {

--- a/src/service/operation-service.js
+++ b/src/service/operation-service.js
@@ -1,3 +1,4 @@
+import { Mutex } from 'async-mutex';
 import {
     OPERATION_ID_STATUS,
     OPERATION_REQUEST_STATUS,
@@ -10,6 +11,18 @@ class OperationService {
         this.repositoryModuleManager = ctx.repositoryModuleManager;
         this.operationIdService = ctx.operationIdService;
         this.commandExecutor = ctx.commandExecutor;
+        this._operationMutexes = new Map();
+    }
+
+    _getOperationMutex(operationId) {
+        if (!this._operationMutexes.has(operationId)) {
+            this._operationMutexes.set(operationId, new Mutex());
+        }
+        return this._operationMutexes.get(operationId);
+    }
+
+    _cleanupOperationMutex(operationId) {
+        this._operationMutexes.delete(operationId);
     }
 
     getOperationName() {
@@ -30,7 +43,8 @@ class OperationService {
     async getResponsesStatuses(responseStatus, errorMessage, operationId) {
         let responses = 0;
         const self = this;
-        await this.operationMutex.runExclusive(async () => {
+        const mutex = this._getOperationMutex(operationId);
+        await mutex.runExclusive(async () => {
             await self.repositoryModuleManager.createOperationResponseRecord(
                 responseStatus,
                 this.operationName,
@@ -65,6 +79,7 @@ class OperationService {
         endStatuses,
         options = {},
     ) {
+        this._cleanupOperationMutex(operationId);
         const { reuseExistingCache = false } = options;
         this.logger.info(`Finalizing ${this.operationName} for operationId: ${operationId}`);
 
@@ -98,6 +113,7 @@ class OperationService {
     }
 
     async markOperationAsFailed(operationId, blockchain, message, errorType) {
+        this._cleanupOperationMutex(operationId);
         this.logger.info(`${this.operationName} for operationId: ${operationId} failed.`);
 
         await this.operationIdService.removeOperationIdCache(operationId);

--- a/src/service/publish-service.js
+++ b/src/service/publish-service.js
@@ -1,4 +1,3 @@
-import { Mutex } from 'async-mutex';
 import OperationService from './operation-service.js';
 
 import {
@@ -23,7 +22,6 @@ class PublishService extends OperationService {
             OPERATION_ID_STATUS.PUBLISH.PUBLISH_END,
             OPERATION_ID_STATUS.COMPLETED,
         ];
-        this.operationMutex = new Mutex();
     }
 
     async processResponse(command, responseStatus, responseData, errorMessage = null) {
@@ -79,6 +77,7 @@ class PublishService extends OperationService {
                 `[PUBLISH] Minimum replication reached for operationId: ${operationId}, ` +
                     `datasetRoot: ${datasetRoot}, completed: ${completedNumber}/${minAckResponses}`,
             );
+            await this.repositoryModuleManager.updateMinAcksReached(operationId, true);
             const cachedData =
                 (await this.operationIdService.getCachedOperationIdData(operationId)) || null;
             await this.markOperationAsCompleted(
@@ -88,7 +87,6 @@ class PublishService extends OperationService {
                 this.completedStatuses,
                 { reuseExistingCache: true },
             );
-            await this.repositoryModuleManager.updateMinAcksReached(operationId, true);
             this.logResponsesSummary(completedNumber, failedNumber);
         }
         // 2.2 Otherwise, mark as failed

--- a/src/service/update-service.js
+++ b/src/service/update-service.js
@@ -1,4 +1,3 @@
-import { Mutex } from 'async-mutex';
 import OperationService from './operation-service.js';
 
 import {
@@ -22,7 +21,6 @@ class UpdateService extends OperationService {
             OPERATION_ID_STATUS.UPDATE.UPDATE_END,
             OPERATION_ID_STATUS.COMPLETED,
         ];
-        this.operationMutex = new Mutex();
     }
 
     async processResponse(command, responseStatus, responseData, errorMessage = null) {


### PR DESCRIPTION
## What

Fixes a concurrency issue where all publish/get/update operations shared a single global mutex per service type, and a race condition where the client would poll for results before signatures were ready.

## Changes

**Per-operation mutex (operation-service.js + all service files)**
- Moved the Mutex from each individual service (publish-service, get-service, ask-service, etc.) into the base OperationService
- Each operationId now gets its own mutex instead of sharing one globally. This means parallel publishes don't block each other anymore.
- Mutexes are cleaned up when operation completes or fails

**MinAcksReached ordering (publish-service.js)**
- updateMinAcksReached is now called *before* markOperationAsCompleted, not after
- Previously the client could poll the result, see COMPLETED status, but minAcksReached would still be false because the flag update hadn't run yet

**Result controller fix (result-http-api-controller-v1.js)**
- Signatures are now returned when status is COMPLETED even if minAcksReached flag wasn't explicitly set (handles the ordering race from the client side too)
- Added try/catch around signature file loading so a missing file doesn't crash the response

## Why

Under parallel load, the global mutex was serializing all operations of the same type. This was unnecessary since operations are independent. The minAcksReached race condition was causing the dkg.js client to get incomplete responses and throw "cannot destructure property identityId" errors.

Made with [Cursor](https://cursor.com)