### PR TITLE
fix: remove sandbox from codex review workflow

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -38,6 +38,7 @@ jobs:
           prompt-file: .codex/review-prompt.md
           output-schema-file: .codex/review-schema.json
           effort: high
+          sandbox: full-auto
 
       - name: Post PR review with inline comments
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -38,7 +38,6 @@ jobs:
           prompt-file: .codex/review-prompt.md
           output-schema-file: .codex/review-schema.json
           effort: high
-          sandbox: read-only
 
       - name: Post PR review with inline comments
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -31,7 +31,10 @@ jobs:
         run: git diff ${{ github.event.pull_request.base.sha }}...HEAD > pr-diff.patch
 
       - name: Allow unprivileged user namespaces for bubblewrap sandbox
-        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        run: |
+          if sudo sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Run Codex review
         id: codex

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -38,7 +38,7 @@ jobs:
           prompt-file: .codex/review-prompt.md
           output-schema-file: .codex/review-schema.json
           effort: high
-          sandbox: full-auto
+          sandbox: workspace-write
 
       - name: Post PR review with inline comments
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Generate PR diff
         run: git diff ${{ github.event.pull_request.base.sha }}...HEAD > pr-diff.patch
 
+      - name: Allow unprivileged user namespaces for bubblewrap sandbox
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Run Codex review
         id: codex
         uses: openai/codex-action@f5c0ca71642badb34c1e66321d8d85685a0fa3dc # v1
@@ -38,7 +41,7 @@ jobs:
           prompt-file: .codex/review-prompt.md
           output-schema-file: .codex/review-schema.json
           effort: high
-          sandbox: danger-full-access
+          sandbox: read-only
 
       - name: Post PR review with inline comments
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -38,7 +38,7 @@ jobs:
           prompt-file: .codex/review-prompt.md
           output-schema-file: .codex/review-schema.json
           effort: high
-          sandbox: workspace-write
+          sandbox: danger-full-access
 
       - name: Post PR review with inline comments
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7


### PR DESCRIPTION
bwrap sandbox fails on GitHub Actions runners with "Failed RTM_NEWADDR: Operation not permitted". GitHub Actions already provides process isolation so the sandbox is unnecessary.

Made-with: Cursor

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
